### PR TITLE
Add R1000 series APU's

### DIFF
--- a/core/ui/menu/qam/powertools_menu.gd
+++ b/core/ui/menu/qam/powertools_menu.gd
@@ -843,6 +843,21 @@ var amd_apu_database := {
 		"min_tdp": 10,
 		"max_boost": 20
 	},
+	'AMD Ryzen Embedded R1305G with Radeon Vega Gfx': {
+		"max_tdp": 25,
+		"min_tdp": 6,
+		"max_boost": 2
+	},
+	'AMD Ryzen Embedded R1505G with Radeon Vega Gfx': {
+		"max_tdp": 25,
+		"min_tdp": 6,
+		"max_boost": 2
+	},
+	'AMD Ryzen Embedded R1606G with Radeon Vega Gfx': {
+		"max_tdp": 10,
+		"min_tdp": 6,
+		"max_boost": 2
+	},
 }
 
 var intel_apu_database := {


### PR DESCRIPTION
Adds support for the R1000 series of APU's from AMD, like the one found in the Atari VCS.

TDP specs taken from here: https://www.amd.com/en/products/embedded-ryzen-r1000-series