### PR TITLE
Move OGUI Steam from OS call to InteractiveProcess

### DIFF
--- a/core/systems/launcher/interactive_process.gd
+++ b/core/systems/launcher/interactive_process.gd
@@ -62,3 +62,21 @@ func stop() -> void:
 	logger.debug("Stopping pid: " + str(pid))
 	OS.kill(pid)
 	pty = null
+
+
+func output_to_log_file(log_file: FileAccess, chunk_size: int = 1024) -> int:
+	if not log_file:
+		logger.warn("Unable to log output. Log file has not been opened.")
+		return ERR_FILE_CANT_OPEN
+	# Keep reading from the process until the buffer is empty
+	if not pty:
+		logger.debug("Unable to read from closed PTY")
+		return ERR_DOES_NOT_EXIST
+
+	# Keep reading from the process until the buffer is empty
+	var buffer := pty.read(chunk_size)
+	while true:
+		log_file.store_buffer(buffer)
+		buffer = pty.read(chunk_size)
+
+	return OK

--- a/core/systems/launcher/interactive_process.gd
+++ b/core/systems/launcher/interactive_process.gd
@@ -70,13 +70,14 @@ func output_to_log_file(log_file: FileAccess, chunk_size: int = 1024) -> int:
 		return ERR_FILE_CANT_OPEN
 	# Keep reading from the process until the buffer is empty
 	if not pty:
-		logger.debug("Unable to read from closed PTY")
+		logger.warn("Unable to read from closed PTY")
 		return ERR_DOES_NOT_EXIST
 
 	# Keep reading from the process until the buffer is empty
 	var buffer := pty.read(chunk_size)
-	while true:
+	while buffer.size() != 0:
 		log_file.store_buffer(buffer)
 		buffer = pty.read(chunk_size)
 
+	log_file.flush()
 	return OK


### PR DESCRIPTION
Move OGUI Steam from OS call to InteractiveProcess to facilitate the following:
- Output steam's stdout to $HOME/.steam-stdout.log for cleaner .ogui-stdout.log and for consistency with other sessions.

This is currently only partially working ATT. Steam's stdout does go to the correct file location, but the buffer seams to only load in waves and truncates frequently. It cannot be used in this state for debug tracking for steam issues.


