### PR TITLE
fix(FocusManager): add 'intercept_children_only' option to only intercept back input if a child has focus

### DIFF
--- a/core/systems/input/focus_manager.gd
+++ b/core/systems/input/focus_manager.gd
@@ -1,13 +1,15 @@
-extends Node
+extends Control
 class_name FocusManager
 
 @export_category("Focus Control")
 @export var current_focus: Control
 @export_category("Refocus on input")
-## If enabled, will intercept input and refocus on the current focus node
+## If enabled, will intercept input and refocus on the current focus node instead
 @export var process_input := false
 ## The InputEvent that will trigger refocusing the current focus node
 @export var refocus_on := "ogui_east"
+## If true, only intercept input and refocus if a descendent node has focus
+@export var intercept_children_only := false
 
 var logger := Log.get_logger("FocusManager", Log.LEVEL.INFO)
 
@@ -223,8 +225,16 @@ func _input(event: InputEvent) -> void:
 	if current_focus.has_focus():
 		return
 
+	# If the active focus node is not a decendent, let someone else handle this
+	# input
+	# TODO: Refactor using a concept of a focus tree, separate from the scene tree
+	if intercept_children_only:
+		var active_focus := get_viewport().gui_get_focus_owner()
+		if not parent.is_ancestor_of(active_focus):
+			return
+
 	# Stop the event from propagating
-	logger.debug("Processing back input!")
+	logger.info(parent.name + " intercepting back input to refocus")
 	get_viewport().set_input_as_handled()
 
 	# Grab focus on the current child

--- a/core/systems/input/focus_manager.tscn
+++ b/core/systems/input/focus_manager.tscn
@@ -2,6 +2,8 @@
 
 [ext_resource type="Script" path="res://core/systems/input/focus_manager.gd" id="1_8tk1v"]
 
-[node name="FocusManager" type="Node"]
+[node name="FocusManager" type="Control"]
 editor_description = "Manages focus neighbors for all Control nodes in the parent container. Also keeps track of the currently focused Control child."
+layout_mode = 3
+anchors_preset = 0
 script = ExtResource("1_8tk1v")

--- a/core/ui/components/plugin_store_item.tscn
+++ b/core/ui/components/plugin_store_item.tscn
@@ -83,7 +83,9 @@ layout_mode = 2
 size_flags_vertical = 8
 
 [node name="FocusManager" parent="MarginContainer/HBoxContainer" instance=ExtResource("2_cng0r")]
+layout_mode = 2
 process_input = true
+intercept_children_only = true
 
 [node name="InstallButton" parent="MarginContainer/HBoxContainer" instance=ExtResource("2_nlpc7")]
 layout_mode = 2

--- a/core/ui/menu/settings/plugin_store_menu.tscn
+++ b/core/ui/menu/settings/plugin_store_menu.tscn
@@ -56,6 +56,7 @@ layout_mode = 2
 
 [node name="FocusManager" parent="VBoxContainer/MarginContainer/HFlowContainer" instance=ExtResource("2_mscek")]
 unique_name_in_owner = true
+process_input = true
 
 [node name="PluginStoreItem" parent="VBoxContainer/MarginContainer/HFlowContainer" instance=ExtResource("1_vqpb4")]
 layout_mode = 2


### PR DESCRIPTION
This will fix some of the focusing issues we've seen, but I think we should consider refactoring how we handle focus in the future. I think implementing something like a `FocusTree`, which tracks the flow of input focus would better.