### PR TITLE
fix(Platform): Fix AOKZOE A1 support

### DIFF
--- a/core/global/input_manager.gd
+++ b/core/global/input_manager.gd
@@ -131,8 +131,8 @@ func _on_gamepad_change(_device: int, _connected: bool) -> void:
 
 		logger.debug("Gamepad disconnected: " + gamepad.phys_path)
 		# Lock the gamepad mappings so we can alter them.
-		gamepad_mutex.lock()
 		orphaned_gamepads[gamepad.phys] = gamepad
+		gamepad_mutex.lock()
 		managed_gamepads.erase(gamepad.phys_path)
 		gamepad_mutex.unlock()
 
@@ -160,8 +160,8 @@ func _on_gamepad_change(_device: int, _connected: bool) -> void:
 			var gamepad: ManagedGamepad = orphaned_gamepads[input_device.get_phys()]
 			gamepad_mutex.lock()
 			managed_gamepads[path] = gamepad
-			orphaned_gamepads.erase(input_device.get_phys())
 			gamepad_mutex.unlock()
+			orphaned_gamepads.erase(input_device.get_phys())
 			logger.debug("Reconnected gamepad at: " + gamepad.phys_path)
 			continue
 		var gamepad := ManagedGamepad.new()
@@ -170,8 +170,8 @@ func _on_gamepad_change(_device: int, _connected: bool) -> void:
 			continue
 		gamepad.xwayland = Gamescope.get_xwayland(Gamescope.XWAYLAND.GAME)
 		gamepad_mutex.lock()
-		managed_gamepads[path] = gamepad
 		virtual_gamepads.append(gamepad.virt_path)
+		managed_gamepads[path] = gamepad
 		gamepad_mutex.unlock()
 		logger.debug("Discovered gamepad at: " + gamepad.phys_path)
 		logger.debug("Created virtual gamepad at: " + gamepad.virt_path)
@@ -179,6 +179,7 @@ func _on_gamepad_change(_device: int, _connected: bool) -> void:
 		# handheld gamepad so we can send events to the correct virtual controller.
 		if is_handheld_gamepad:
 			handheld_gamepad.set_gamepad_device(gamepad)
+	# If we're using a handheld, open the device.
 	if handheld_gamepad and not handheld_gamepad.is_open():
 		if handheld_gamepad.open() != OK:
 			logger.error("Unable to open handheld keyboard device.")

--- a/core/global/input_manager.gd
+++ b/core/global/input_manager.gd
@@ -130,9 +130,9 @@ func _on_gamepad_change(_device: int, _connected: bool) -> void:
 			continue
 
 		logger.debug("Gamepad disconnected: " + gamepad.phys_path)
-		orphaned_gamepads[gamepad.phys] = gamepad
 		# Lock the gamepad mappings so we can alter them.
 		gamepad_mutex.lock()
+		orphaned_gamepads[gamepad.phys] = gamepad
 		managed_gamepads.erase(gamepad.phys_path)
 		gamepad_mutex.unlock()
 
@@ -160,8 +160,8 @@ func _on_gamepad_change(_device: int, _connected: bool) -> void:
 			var gamepad: ManagedGamepad = orphaned_gamepads[input_device.get_phys()]
 			gamepad_mutex.lock()
 			managed_gamepads[path] = gamepad
-			gamepad_mutex.unlock()
 			orphaned_gamepads.erase(input_device.get_phys())
+			gamepad_mutex.unlock()
 			logger.debug("Reconnected gamepad at: " + gamepad.phys_path)
 			continue
 		var gamepad := ManagedGamepad.new()
@@ -179,6 +179,9 @@ func _on_gamepad_change(_device: int, _connected: bool) -> void:
 		# handheld gamepad so we can send events to the correct virtual controller.
 		if is_handheld_gamepad:
 			handheld_gamepad.set_gamepad_device(gamepad)
+	if handheld_gamepad and not handheld_gamepad.is_open():
+		if handheld_gamepad.open() != OK:
+			logger.error("Unable to open handheld keyboard device.")
 	logger.debug("Finished configuring detected controllers")
 
 

--- a/core/global/platform.gd
+++ b/core/global/platform.gd
@@ -194,7 +194,7 @@ func _read_dmi() -> PLATFORM:
 		return PLATFORM.ABERNIC_GEN1
 	if product_name == "AOKZOE A1 AR07" and vendor_name == "AOKZOE":
 		logger.debug("Detected AOKZOE A1 platform")
-		return PLATFORM.ONEXPLAYER_GEN2
+		return PLATFORM.AOKZOE_GEN1
 	elif product_name in ["AYANEO 2", "GEEK"] and vendor_name == "AYANEO":
 		logger.debug("Detected AYANEO 2 platform")
 		return PLATFORM.AYANEO_GEN4

--- a/core/systems/input/handheld_gamepad.gd
+++ b/core/systems/input/handheld_gamepad.gd
@@ -287,6 +287,7 @@ func open() -> int:
 		logger.error("Unable to open event device: " + kb_event_path +". Handheld Gamepad not configured.")
 		kb_device = null
 		return result
+	logger.debug("Successfully opened " + kb_device.get_name() + " at " + kb_event_path)
 	# Grab exclusive access over the physical device
 	if not "--disable-grab-gamepad" in OS.get_cmdline_args():
 		result = kb_device.grab(true)
@@ -294,7 +295,6 @@ func open() -> int:
 			logger.error("Unable to grab " + kb_device.get_name())
 			return result
 		logger.debug("Grabbed " + kb_device.get_name())
-	logger.debug("Successfully opened " + kb_device.get_name() + " at " + kb_event_path)
 	return result
 
 
@@ -323,13 +323,10 @@ func set_kb_event_path(path: String) -> void:
 
 ## Sets the associated ManagedGamepad so it can recieve virtual device events
 ## that are mapped via the mapped_events Array.
-func set_gamepad_device(gamepad: ManagedGamepad) -> bool:
+func set_gamepad_device(gamepad: ManagedGamepad) -> void:
 	gamepad_device = gamepad
-	if open() != OK:
-		logger.warn("Unable to configure handheld gamepad device")
-		return false
 	logger.info("Configured handeheld gamepad device")
-	return true
+	return
 
 
 ## Custom sort method that returns true if the first InputDeviceEvent  is less 
@@ -340,3 +337,9 @@ func _sort_events(event1: InputDeviceEvent, event2: InputDeviceEvent) -> bool:
 	if event1.get_code() != event2.get_code():
 		return event1.get_code() < event2.get_code()
 	return event1.get_value() < event2.get_value()
+
+## Returns if the kb device is open or not.
+func is_open() -> bool:
+	if not kb_device:
+		return false
+	return kb_device.is_open()


### PR DESCRIPTION
* Fix incorrect platform for AOKZOE A1
* Fix orphaned_gamepad array being modified outside of mutex.lock()
* Fix bug where a device who's gamepad event was read before the keyboard device could fail to open properly.