### PR TITLE
fix(threading): Add thread deconstructor and ThreadPool

### DIFF
--- a/core/systems/threading/shared_thread.gd
+++ b/core/systems/threading/shared_thread.gd
@@ -29,6 +29,11 @@ func _init() -> void:
 	watchdog.add_thread(self)
 
 
+func _notification(what: int):
+	if what == NOTIFICATION_PREDELETE:
+		stop()
+		
+
 ## Starts the thread for the thread group
 func start() -> void:
 	if running:

--- a/core/systems/threading/thread_pool.gd
+++ b/core/systems/threading/thread_pool.gd
@@ -1,0 +1,112 @@
+extends Resource
+class_name ThreadPool
+
+## Resource that allows executing methods in a thread pool
+##
+## By default, the thread pool will create a thread for each detected core
+## on the running machine. Each thread sleeps until a task is queued when
+## [method exec] is called. When a task is queued, a thread will wake up and
+## start working on the task until it is completed.
+
+signal exec_completed(task: Task)
+
+## Name of the thread pool
+@export var name := "ThreadPool"
+## Number of threads to create in the thread pool
+@export var size := OS.get_processor_count()
+
+var running := false
+var threads: Array[Thread] = []
+var semaphore := Semaphore.new()
+var mutex := Mutex.new()
+var queue: Array[Task] = []
+var logger := Log.get_logger("ThreadPool", Log.LEVEL.DEBUG)
+
+
+## A queued task to run in the thread pool
+class Task extends RefCounted:
+	var method: Callable
+	var ret: Variant
+
+
+func _notification(what: int):
+	if what == NOTIFICATION_PREDELETE:
+		stop()
+
+
+## Starts the threads for the thread pool
+func start() -> void:
+	if is_running():
+		return
+	for i in range(size):
+		var thread := Thread.new()
+		thread.start(_process.bind(i))
+		threads.append(thread)
+	mutex.lock()
+	running = true
+	mutex.unlock()
+
+
+## Stops the thread pool
+func stop() -> void:
+	if is_running():
+		return
+	mutex.lock()
+	running = false
+	mutex.unlock()
+	for thread in threads:
+		semaphore.post()
+		thread.wait_to_finish()
+
+
+## Returns whether or not the thread pool is running
+func is_running() -> bool:
+	mutex.lock()
+	var run := running
+	mutex.unlock()
+	return run
+
+
+## Calls the given method from the thread pool. Internally, this queues the given 
+## method and awaits it to be called during the process loop. You should await 
+## this method if your method returns something. 
+## E.g. [code]var result = await thread_pool.exec(myfund.bind("myarg"))[/code]
+func exec(method: Callable) -> Variant:
+	if size == 0:
+		return method.call()
+	var task := Task.new()
+	task.method = method
+	mutex.lock()
+	queue.append(task)
+	mutex.unlock()
+	semaphore.post()
+	var out: Task
+	while out != task:
+		out = await exec_completed
+	return out.ret
+
+
+## Each thread in the pool waits for tasks and executes methods from the queue
+func _process(id: int) -> void:
+	logger.info("Started thread: " + str(id))
+	while true:
+		semaphore.wait()
+		mutex.lock()
+		var should_exit := not running
+		mutex.unlock()
+
+		if should_exit:
+			break
+
+		mutex.lock()
+		var task := queue.pop_front() as Task
+		mutex.unlock()
+		
+		logger.debug("Processing task in thread " + str(id))
+		_async_call(task)
+
+
+func _async_call(task: Task) -> void:
+	var ret = await task.method.call()
+	task.ret = ret
+	emit_signal.call_deferred("exec_completed", task)

--- a/core/systems/threading/thread_pool.tres
+++ b/core/systems/threading/thread_pool.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="ThreadPool" load_steps=2 format=3 uid="uid://durxsxdlmghrq"]
+
+[ext_resource type="Script" path="res://core/systems/threading/thread_pool.gd" id="1_fb4e5"]
+
+[resource]
+script = ExtResource("1_fb4e5")
+name = "ThreadPool"
+size = null

--- a/core/systems/threading/thread_pool_test.gd
+++ b/core/systems/threading/thread_pool_test.gd
@@ -1,0 +1,24 @@
+extends Test
+
+var thread_pool := ThreadPool.new()
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	thread_pool.start()
+	print("Thread pool started")
+	var sleep1 := func():
+		OS.delay_msec(5000)
+		print("sleep1 done")
+		return "sleep1"
+	var sleep2 := func():
+		OS.delay_msec(10000)
+		print("sleep2 done")
+		return "sleep2"
+		
+	thread_pool.exec(sleep1)
+	thread_pool.exec(sleep2)
+
+
+func _exit_tree() -> void:
+	thread_pool.stop()

--- a/core/systems/threading/thread_pool_test.tscn
+++ b/core/systems/threading/thread_pool_test.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3 uid="uid://di2r8o1y5ls8l"]
+
+[ext_resource type="Script" path="res://core/systems/threading/thread_pool_test.gd" id="1_7lc0s"]
+
+[node name="ThreadPoolTest" type="Node"]
+script = ExtResource("1_7lc0s")
+test_name = "TestThreadPool"

--- a/core/systems/threading/watchdog_thread.gd
+++ b/core/systems/threading/watchdog_thread.gd
@@ -20,6 +20,11 @@ func _init() -> void:
 	logger.info("Watchdog thread started")
 
 
+func _notification(what: int):
+	if what == NOTIFICATION_PREDELETE:
+		stop()
+
+
 ## Add the given shared thread
 func add_thread(thread: SharedThread) -> void:
 	mutex.lock()


### PR DESCRIPTION
This PR adds the `ThreadPool` class and shared resource which allows you to execute methods in a separate available thread. By default, a thread pool is created with a number of threads equal to the CPU core count. Each thread waits for tasks to be queued by `ThreadPool.exec()`. When a task is queued, one of the threads from the pool will wake up and begin processing the task until it is completed.

Example:

```gdscript
var thread_pool := load("res://core/systems/threading/thread_pool.tres")
thread_pool.start()

var output = await thread_pool.exec(my_func)
```