### PR TITLE
fix(only-qam): Use fd moving instead of sandboxing

### DIFF
--- a/core/systems/input/handheld_gamepad.gd
+++ b/core/systems/input/handheld_gamepad.gd
@@ -295,6 +295,7 @@ func open() -> int:
 			logger.error("Unable to grab " + kb_device.get_name())
 			return result
 		logger.debug("Grabbed " + kb_device.get_name())
+	hide_event_device(kb_event_path)
 	return result
 
 
@@ -343,3 +344,27 @@ func is_open() -> bool:
 	if not kb_device:
 		return false
 	return kb_device.is_open()
+
+# TODO: These are duplicated in InputManager. Find a way to have them only once.
+func hide_event_device(phys_path: String) -> int:
+	return _manage_event_path("hide", _get_event_from_phys(phys_path))
+
+
+
+func restore_event_device(phys_path: String) -> int:
+	return _manage_event_path("restore", _get_event_from_phys(phys_path))
+
+
+func _manage_event_path(action: String, event_id: String) -> int:
+	var command := "/usr/share/opengamepadui/scripts/manage_input"
+	var args := [action, event_id] 
+	var output = []
+	logger.debug("Start _manage_event_path with command : " + command + "  ".join(args))
+	var exit_code := OS.execute(command, args, output)
+	logger.debug("Output: " + str(output))
+	logger.debug("Exit code: " +str(exit_code))
+	return exit_code
+
+
+func _get_event_from_phys(phys_path: String)  -> String:
+	return phys_path.lstrip("/dev/input")

--- a/core/ui/only_qam_ui/only_qam_main.gd
+++ b/core/ui/only_qam_ui/only_qam_main.gd
@@ -102,14 +102,6 @@ func _start_underlay_process(args: Array, log_path: String) -> void:
 	var command: String = args[0]
 	args.remove_at(0)
 	underlay_process = InteractiveProcess.new(command, args)
-#	var sandbox := PackedStringArray()
-#	sandbox.append_array(["--noprofile"])
-#	var blacklist := InputManager.get_managed_gamepads()
-#	for device in blacklist:
-#		sandbox.append("--blacklist=%s" % device)
-#	sandbox.append("--")
-#	sandbox.append_array(args)
-#	underlay_process = InteractiveProcess.new("firejail", sandbox)
 	if underlay_process.start() != OK:
 		logger.error("Failed to start child process.")
 		return

--- a/core/ui/only_qam_ui/only_qam_main.gd
+++ b/core/ui/only_qam_ui/only_qam_main.gd
@@ -99,15 +99,17 @@ func _start_underlay_process(args: Array, log_path: String) -> void:
 		logger.warn("Got error opening log file.")
 	else:
 		logger.info("Started logging underlay process at " + log_path)
-	# Launch underlay in the sandbox
-	var sandbox := PackedStringArray()
-	sandbox.append_array(["--noprofile"])
-	var blacklist := InputManager.get_managed_gamepads()
-	for device in blacklist:
-		sandbox.append("--blacklist=%s" % device)
-	sandbox.append("--")
-	sandbox.append_array(args)
-	underlay_process = InteractiveProcess.new("firejail", sandbox)
+	var command: String = args[0]
+	args.remove_at(0)
+	underlay_process = InteractiveProcess.new(command, args)
+#	var sandbox := PackedStringArray()
+#	sandbox.append_array(["--noprofile"])
+#	var blacklist := InputManager.get_managed_gamepads()
+#	for device in blacklist:
+#		sandbox.append("--blacklist=%s" % device)
+#	sandbox.append("--")
+#	sandbox.append_array(args)
+#	underlay_process = InteractiveProcess.new("firejail", sandbox)
 	if underlay_process.start() != OK:
 		logger.error("Failed to start child process.")
 		return

--- a/rootfs/usr/share/opengamepadui/scripts/manage_input
+++ b/rootfs/usr/share/opengamepadui/scripts/manage_input
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+if [[ $EUID -ne 0 ]]; then
+  exec pkexec --disable-internal-agent "$0" "$@"
+fi
+
+ensure_hidden_exists() {
+  if [[ ! -d "/dev/input/.hidden" ]]; then
+    mkdir /dev/input/.hidden
+  fi
+}
+
+hide() {
+  mv /dev/input/${1} /dev/input/.hidden/${1}
+}
+
+restore() {
+  mv /dev/input/.hidden/${1} /dev/input/${1}
+}
+
+ensure_hidden_exists
+
+if [[ $1 == "hide" ]]; then
+  if [[ ! -e "/dev/input/${2}" ]]; then
+    echo "UInput device ${2} does not exist."
+    exit 1
+  fi
+  hide $2
+
+elif [[ $1 == "restore" ]]; then
+  if [[ ! -e "/dev/input/.hidden/${2}" ]]; then
+    echo "UInput device ${2} is not hidden."
+    exit 1
+  fi
+  restore $2
+fi

--- a/rootfs/usr/share/polkit-1/actions/org.shadowblip.manage_input.policy
+++ b/rootfs/usr/share/polkit-1/actions/org.shadowblip.manage_input.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>OpenGamepadUI Mange Input</vendor>
+  <vendor_url>http://www.github.com/shadowblip</vendor_url>
+
+  <action id="org.shadowblip.pkexec.manage_input">
+    <description>Hide and r estore input devices</description>
+    <icon_name>package-x-generic</icon_name> 
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/share/opengamepadui/scripts/manage_input</annotate>
+  </action>
+
+</policyconfig>
+


### PR DESCRIPTION
Use fd moving instead of sandboxing for only-qam, solved the following issues:
- pkexec no longer fails in only-qam mode
- Inputs connected after bootup lo longer fail to discover or create duplicate input.
- Sandbox no longer required to hide input devices with uaccess in --only-qam