### PR TITLE
fix(InputManager): Use FORCE_INPUT_UACCESS

### DIFF
--- a/rootfs/usr/lib/udev/hwdb.d/59-opengamepadui-handheld.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/59-opengamepadui-handheld.hwdb
@@ -1,18 +1,18 @@
 ## ABERNIC DEVICES
 evdev:name:AT Translated Set 2 keyboard:dmi:*:svnAbernic:*
-  ID_INPUT_JOYSTICK=1
+  FORCE_INPUT_UACCESS=1
 
 ## AOKZOE DEVICES
 evdev:name:AT Translated Set 2 keyboard:dmi:*:svnAOKZOE:*
-  ID_INPUT_JOYSTICK=1
+  FORCE_INPUT_UACCESS=1
 
 ## AYANEO DEVICES
 evdev:name:AT Translated Set 2 keyboard:dmi:*:svnAYA NEO:*
-  ID_INPUT_JOYSTICK=1
+  FORCE_INPUT_UACCESS=1
 
 evdev:name:AT Translated Set 2 keyboard:dmi:*:svnAYANEO:*
-  ID_INPUT_JOYSTICK=1
+  FORCE_INPUT_UACCESS=1
 
 ## ONEXPLAYER DEVICES
 evdev:name:AT Translated Set 2 keyboard:dmi:*:svnONE-NETBOOK*:pnONE*:
-  ID_INPUT_JOYSTICK=1
+  FORCE_INPUT_UACCESS=1

--- a/rootfs/usr/lib/udev/rules.d/10-opengamepadui-handheld.rules
+++ b/rootfs/usr/lib/udev/rules.d/10-opengamepadui-handheld.rules
@@ -1,2 +1,0 @@
-# Enables keycodes and user access for the input devices that provide back button events.
-ACTION=="add|change", KERNEL=="event[0-9]*", ATTRS{idVendor}=="2f24", ATTRS{idProduct}=="0135", ENV{ID_INPUT_KEYBOARD}="1", ENV{ID_INPUT_JOYSTICK}="1"

--- a/rootfs/usr/lib/udev/rules.d/61-opengamepadui-handheld.rules
+++ b/rootfs/usr/lib/udev/rules.d/61-opengamepadui-handheld.rules
@@ -1,0 +1,5 @@
+# Adds uaccess to Handheld Controller and makes it act like a joystick.
+ACTION=="add|change", KERNEL=="event[0-9]*", SUBSYSTEM=="input", ENV{FORCE_INPUT_UACCESS}=="1", MODE="0660", TAG+="uaccess"
+
+# For GPD Devices, enables keycodes and user access for the input device that provides events for the two rear buttons.
+ACTION=="add|change", KERNEL=="event[0-9]*", ATTRS{idVendor}=="2f24", ATTRS{idProduct}=="0135", ENV{ID_INPUT_KEYBOARD}="1", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
This is a better method of adding uaccess to keyboard/mouse type devices. This new method does the following:
- No longer has collisions with other ID_INPUT_JOYSTICK rules that could cause keyboard devices to trigger looping sleep/wake cycles.
- No longer adds excessive and unnecessary input device event codes.
