### PR TITLE
fix(logging): Add LOG_LEVEL env var to set log level

### DIFF
--- a/core/main.gd
+++ b/core/main.gd
@@ -5,6 +5,12 @@ var args := OS.get_cmdline_args()
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	# Display a custom help if 'help' in args
+	if "help" in args:
+		_show_help()
+		get_tree().quit()
+		return
+	
 	# Launch old ui
 	if "--vapor-ui" in args:
 		# in only-qam mode
@@ -20,3 +26,23 @@ func _ready() -> void:
 		return
 	# Launch the main interface
 	get_tree().change_scene_to_file("res://core/ui/card_ui/card_ui.tscn")
+
+
+# Show command-line help options
+func _show_help() -> void:
+	print("OpenGamepadUI open source game launcher")
+	print("")
+	print("Usage:")
+	print("  ", OS.get_executable_path(), " [flags] [command]")
+	print("")
+	print("Available Commands:")
+	print("  help             Display this help message")
+	print("")
+	print("Flags:")
+	print("  --vapor-ui       Load Vapor UI")
+	print("  --only-qam       Load the only-qam UI")
+	print("")
+	print("Environment Variables:")
+	print("  LOG_LEVEL        Set the global log level (debug,info,warn,error)")
+	print("  LOG_LEVEL_<NAME> Set the log level for one logger (debug,info,warn,error)")
+	print("")

--- a/core/systems/debug/log_manager.gd
+++ b/core/systems/debug/log_manager.gd
@@ -30,12 +30,12 @@ func register(logger: Log.Logger) -> void:
 	# E.g. LOG_LEVEL=debug opengamepadui
 	var env_level := OS.get_environment("LOG_LEVEL")
 	if env_level != "":
-		match env_level:
+		match env_level.to_lower():
 			"debug", "trace":
 				logger.set_level(Log.LEVEL.DEBUG)
 			"info":
 				logger.set_level(Log.LEVEL.INFO)
-			"warn":
+			"warn", "warning":
 				logger.set_level(Log.LEVEL.WARN)
 			"error":
 				logger.set_level(Log.LEVEL.ERROR)
@@ -46,12 +46,12 @@ func register(logger: Log.Logger) -> void:
 	var env_suffix := logger.get_name().to_upper().replace(" ", "")
 	var env_named_level := OS.get_environment("LOG_LEVEL_" + env_suffix)
 	if env_named_level != "":
-		match env_named_level:
+		match env_named_level.to_lower():
 			"debug", "trace":
 				logger.set_level(Log.LEVEL.DEBUG)
 			"info":
 				logger.set_level(Log.LEVEL.INFO)
-			"warn":
+			"warn", "warning":
 				logger.set_level(Log.LEVEL.WARN)
 			"error":
 				logger.set_level(Log.LEVEL.ERROR)
@@ -69,7 +69,6 @@ func set_global_log_level(level: Log.LEVEL) -> void:
 	mutex.lock()
 	var logger_names := loggers_by_name.keys()
 	mutex.unlock()
-	print("SETTING GLOBAL LOG LEVEL!")
 	for logger in logger_names:
 		set_log_level(logger, level)
 

--- a/core/systems/debug/log_manager.gd
+++ b/core/systems/debug/log_manager.gd
@@ -28,33 +28,13 @@ func register(logger: Log.Logger) -> void:
 
 	# If the global log level variable was set on start, update the logger's log level.
 	# E.g. LOG_LEVEL=debug opengamepadui
-	var env_level := OS.get_environment("LOG_LEVEL")
-	if env_level != "":
-		match env_level.to_lower():
-			"debug", "trace":
-				logger.set_level(Log.LEVEL.DEBUG)
-			"info":
-				logger.set_level(Log.LEVEL.INFO)
-			"warn", "warning":
-				logger.set_level(Log.LEVEL.WARN)
-			"error":
-				logger.set_level(Log.LEVEL.ERROR)
-	
+	set_log_level_from_env(logger, "LOG_LEVEL")
+
 	# Check to see if there is a named logger log level variable set. If there is,
 	# update the log level.
 	# E.g. LOG_LEVEL_BOXARTMANAGER=debug opengamepadui
 	var env_suffix := logger.get_name().to_upper().replace(" ", "")
-	var env_named_level := OS.get_environment("LOG_LEVEL_" + env_suffix)
-	if env_named_level != "":
-		match env_named_level.to_lower():
-			"debug", "trace":
-				logger.set_level(Log.LEVEL.DEBUG)
-			"info":
-				logger.set_level(Log.LEVEL.INFO)
-			"warn", "warning":
-				logger.set_level(Log.LEVEL.WARN)
-			"error":
-				logger.set_level(Log.LEVEL.ERROR)
+	set_log_level_from_env(logger, "LOG_LEVEL_" + env_suffix)
 
 	# NOTE: Decrement the reference count so the logger gets garbage collected
 	# if we're the only one referencing it.
@@ -87,6 +67,23 @@ func set_log_level(name: String, level: Log.LEVEL) -> void:
 			continue
 		var logger := l as Log.Logger
 		logger.set_level(level)
+
+
+## Looks up the given environment variable and sets the log level on the given
+## logger if the variable exists.
+func set_log_level_from_env(logger: Log.Logger, env_var: String) -> void:
+	var env_level := OS.get_environment(env_var)
+	if env_level == "":
+		return
+	match env_level.to_lower():
+		"debug", "trace":
+			logger.set_level(Log.LEVEL.DEBUG)
+		"info":
+			logger.set_level(Log.LEVEL.INFO)
+		"warn", "warning":
+			logger.set_level(Log.LEVEL.WARN)
+		"error":
+			logger.set_level(Log.LEVEL.ERROR)
 
 
 ## Return a list of loggers that are currently registered

--- a/core/systems/input/focus_group.gd
+++ b/core/systems/input/focus_group.gd
@@ -30,6 +30,7 @@ var logger := Log.get_logger("FocusGroup", Log.LEVEL.INFO)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	logger.debug("FocusGroup ready")
 	# Create a focus stack if none is defined
 	if not focus_stack:
 		focus_stack = FocusStack.new()

--- a/core/systems/input/focus_group.gd
+++ b/core/systems/input/focus_group.gd
@@ -30,7 +30,6 @@ var logger := Log.get_logger("FocusGroup", Log.LEVEL.INFO)
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	logger.debug("FocusGroup ready")
 	# Create a focus stack if none is defined
 	if not focus_stack:
 		focus_stack = FocusStack.new()

--- a/core/systems/state/state_machine.gd
+++ b/core/systems/state/state_machine.gd
@@ -27,7 +27,7 @@ func _on_state_changed(from: State, to: State) -> void:
 	if to != null:
 		to_str = to.name
 		to.state_entered.emit(from)
-	if logger._name != logger_name:
+	if logger.get_name() != logger_name:
 		logger = Log.get_logger(logger_name)
 	logger.info("Switched from state {0} to {1}".format([from_str, to_str]))
 	var state_names := PackedStringArray()

--- a/core/ui/vapor_ui/settings/logging_settings_menu.gd
+++ b/core/ui/vapor_ui/settings/logging_settings_menu.gd
@@ -12,9 +12,6 @@ var log_manager := preload("res://core/global/log_manager.tres")
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	# Set the default log level on all loggers
-	log_manager.set_global_log_level(Log.LEVEL.INFO)
-	
 	# Populate the global log levels
 	global_dropdown.clear()
 	global_dropdown.add_item("debug")


### PR DESCRIPTION
Users can now add `LOG_LEVEL=<level>` (debug, info, warn, error) and/or `LOG_LEVEL_<NAME>=<level>` to turn on/off log levels using an environment variable.

If users are using opengamepadui-session, they can export these variables in `~/.config/environment.d/opengamepadui-session.conf`.

Example:

```bash
export LOG_LEVEL=info
export LOG_LEVEL_FOCUSGROUP=debug
export LOG_LEVEL_INPUTMANAGER=debug
```