### PR TITLE
Better Library hot-reloading

### DIFF
--- a/core/global/library_manager.gd
+++ b/core/global/library_manager.gd
@@ -331,7 +331,7 @@ func get_library_by_id(id: String) -> Library:
 func get_libraries() -> Array[Library]:
 	var libraries: Array[Library] = []
 	libraries.assign(_libraries.values())
-	print("Got libraries: ", libraries)
+	logger.debug("Got libraries: " + str(libraries))
 
 	return libraries
 

--- a/core/systems/input/focus_group.gd
+++ b/core/systems/input/focus_group.gd
@@ -433,13 +433,13 @@ func _vbox_set_focus_tree(control_children: Array[Control]) -> void:
 		child.focus_neighbor_right = control_children[i].get_path()
 		
 		# Set the focus group neighbors if they are defined
-		if focus_neighbor_top and i == 0:
+		if is_instance_valid(focus_neighbor_top) and i == 0:
 			child.focus_neighbor_top = focus_neighbor_top.neighbor_control.get_path()
-		if focus_neighbor_bottom and i == control_children.size() - 1:
+		if is_instance_valid(focus_neighbor_bottom) and i == control_children.size() - 1:
 			child.focus_neighbor_bottom = focus_neighbor_bottom.neighbor_control.get_path()
-		if focus_neighbor_left:
+		if is_instance_valid(focus_neighbor_left):
 			child.focus_neighbor_left = focus_neighbor_left.neighbor_control.get_path()
-		if focus_neighbor_right:
+		if is_instance_valid(focus_neighbor_right):
 			child.focus_neighbor_right = focus_neighbor_right.neighbor_control.get_path()
 
 		i += 1


### PR DESCRIPTION
This change adds a `set_library_item()` method to `GameCard` which will listen for signals when a library item is removed and automatically free itself. This provides better live library reloading.

Fixes #34