### PR TITLE
fix(PowerTools): Add commit write and reset to amdgpuclock changes.

### DIFF
--- a/rootfs/usr/share/opengamepadui/scripts/powertools
+++ b/rootfs/usr/share/opengamepadui/scripts/powertools
@@ -26,6 +26,7 @@ smtToggle(){
 ## AMD APU
 amdGpuClock(){
   /usr/bin/echo "s $1 $2" > /sys/class/drm/card0/device/pp_od_clk_voltage
+  /usr/bin/echo "c" > /sys/class/drm/card0/device/pp_od_clk_voltage
 }
 
 ryzenadjLong(){
@@ -37,6 +38,7 @@ ryzenadjShort(){
 }
 
 setPDFPLM() { # set power_dpm_force_performace_level mode
+  /usr/bin/echo "r" > /sys/class/drm/card0/device/pp_od_clk_voltage
   /usr/bin/echo $1 > /sys/class/drm/card0/device/power_dpm_force_performance_level
 }
 


### PR DESCRIPTION
- Fixes GPU Clock not getting set when changing mix/max settings.