### PR TITLE
fix(PowerTools): Fix multiple PowerTools functions

### DIFF
--- a/core/ui/vapor_ui/qam/powertools_menu.gd
+++ b/core/ui/vapor_ui/qam/powertools_menu.gd
@@ -347,26 +347,29 @@ func _on_gpu_temp_limit_changed(value: float) -> void:
 			pass
 
 
-# Called to set the max GPU freq
+# Called when gpu_freq_max_slider.value is changed.
 func _on_max_gpu_freq_changed(value: float) -> void:
 	if value < gpu_freq_min_slider.value:
 		gpu_freq_min_slider.value = value
-	match gpu.vendor:
-		"AMD":
-			_setup_callback_exec(powertools_path, ["amdGpuClock", "1", str(value)])
-		"Intel":
-			_setup_callback_exec(powertools_path, ["intelGpuClock", "gt_max_freq_mhz", str(value)])
+	_on_gpu_freq_changed(gpu_freq_min_slider.value, value)
 
-
-# Called to set the min GPU freq
+# Called when gpu_freq_min_slider.value is changed.
 func _on_min_gpu_freq_changed(value: float) -> void:
 	if value > gpu_freq_max_slider.value:
 		gpu_freq_max_slider.value = value
+	_on_gpu_freq_changed(value, gpu_freq_max_slider.value)
+
+
+# Set the GPU min/max freq.
+func _on_gpu_freq_changed(min: float, max: float) -> void:
+	var cmd := ""
 	match gpu.vendor:
 		"AMD":
-			_setup_callback_exec(powertools_path, ["amdGpuClock", "0", str(value)])
+			cmd = "amdGpuClock"
 		"Intel":
-			_setup_callback_exec(powertools_path, ["intelGpuClock", "gt_min_freq_mhz", str(value)])
+			cmd = "intelGpuClock"
+
+	_setup_callback_exec(powertools_path, [cmd, str(min), str(max)])
 
 
 # Called to set the base average TDP

--- a/rootfs/usr/share/opengamepadui/scripts/powertools
+++ b/rootfs/usr/share/opengamepadui/scripts/powertools
@@ -25,7 +25,8 @@ smtToggle(){
 
 ## AMD APU
 amdGpuClock(){
-  /usr/bin/echo "s $1 $2" > /sys/class/drm/card0/device/pp_od_clk_voltage
+  /usr/bin/echo "s 0 ${1}" > /sys/class/drm/card0/device/pp_od_clk_voltage
+  /usr/bin/echo "s 1 ${2}" > /sys/class/drm/card0/device/pp_od_clk_voltage
   /usr/bin/echo "c" > /sys/class/drm/card0/device/pp_od_clk_voltage
 }
 
@@ -37,18 +38,18 @@ ryzenadjShort(){
   /usr/bin/ryzenadj $1
 }
 
-setPDFPLM() { # set power_dpm_force_performace_level mode
-  /usr/bin/echo "r" > /sys/class/drm/card0/device/pp_od_clk_voltage
+setAmdPerfLevelValue() { # set power_dpm_force_performace_level mode
   /usr/bin/echo $1 > /sys/class/drm/card0/device/power_dpm_force_performance_level
 }
 
-setPDFPLW() { # set power_dpm_force_performace_level write
+setAmdPerfLevelWrite() { # set power_dpm_force_performace_level write
   /usr/bin/chmod a+w /sys/class/drm/card0/device/power_dpm_force_performance_level
 }
 
 ## INTEL iGPU
 setRapl(){ #TDP Control
-  /usr/bin/echo $2 > /sys/class/powercap/intel-rapl/intel-rapl:0/${1}
+  /usr/bin/echo $1 > /sys/class/powercap/intel-rapl/intel-rapl:0/gt_min_freq_mhz
+  /usr/bin/echo $2 > /sys/class/powercap/intel-rapl/intel-rapl:0/gt_max_freq_mhz
 }
 
 intelGpuClock(){
@@ -74,9 +75,9 @@ elif [[ $1 == "amdGpuClock" ]]; then
 
 elif [[ $1 == "pdfpl" ]]; then
   if [[ $2 == "write" ]]; then
-    setPDFPLW
+    setAmdPerfLevelWrite
   else
-    setPDFPLM $2
+    setAmdPerfLevelValue $2
   fi
 
 elif [[ $1 == "ryzenadj" ]]; then


### PR DESCRIPTION
This PR should be merged after we find a fix for FocusManager on a non visible node or the PT menu will break completely.

- Fix GPUCLK setting properly for AMD GPU's.
- Fix GPUCLK setting properly for Intel GPU's.
- Fix manual/auto toggle for writing to performance mode for AMDPGU's.
- Disable core count select when SMT is disabled.
- Fix SMT toggle setting too few cores on some CPU's when toggled.
- Fix CPU Boost toggle appearing when using amd_pstate driver, as the sysfs character file to toggle boost is not present using that governor.