### PR TITLE
feat(RunningApp): add window switching within a given app

### DIFF
--- a/core/systems/launcher/running_app.gd
+++ b/core/systems/launcher/running_app.gd
@@ -281,6 +281,24 @@ func grab_focus() -> void:
 	focused = true
 
 
+## Switches the app window to the given window ID. Returns an error if unable
+## to switch to the window
+func switch_window(win_id: int, focus: bool = true) -> int:
+	# Error if the window does not belong to the running app
+	if not win_id in window_ids:
+		return ERR_DOES_NOT_EXIST
+	
+	# Check if this app is a focusable window.
+	if not win_id in Gamescope.get_focusable_windows():
+		return ERR_UNAVAILABLE
+	
+	# Update the window ID and optionally grab focus
+	window_id = win_id
+	if focus:
+		grab_focus()
+	return OK
+
+
 ## Kill the running app
 func kill(sig: Reaper.SIG = Reaper.SIG.TERM) -> void:
 	state = STATE.STOPPING

--- a/core/ui/card_ui/navigation/running_game_card.tscn
+++ b/core/ui/card_ui/navigation/running_game_card.tscn
@@ -127,6 +127,9 @@ unique_name_in_owner = true
 current_focus = NodePath("../ResumeButton")
 focus_stack = ExtResource("6_xmlue")
 
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/VBoxContainer/ContentContainer"]
+layout_mode = 2
+
 [node name="ResumeButton" parent="MarginContainer/VBoxContainer/ContentContainer" instance=ExtResource("8_ixs6g")]
 unique_name_in_owner = true
 layout_mode = 2


### PR DESCRIPTION
This adds buttons in the running game card in the main menu that allows users to switch between multiple windows from a single app.