### PR TITLE
feat(HelpMenu): Add help menu with interface shortcuts

### DIFF
--- a/assets/state/states/help_menu.tres
+++ b/assets/state/states/help_menu.tres
@@ -1,0 +1,8 @@
+[gd_resource type="Resource" script_class="State" load_steps=2 format=3 uid="uid://db5gbdl3xgwlq"]
+
+[ext_resource type="Script" path="res://core/systems/state/state.gd" id="1_hu8ma"]
+
+[resource]
+script = ExtResource("1_hu8ma")
+name = "help_menu"
+data = {}

--- a/core/ui/card_ui/card_ui.tscn
+++ b/core/ui/card_ui/card_ui.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=3 uid="uid://fhriwlhm0lcj"]
+[gd_scene load_steps=32 format=3 uid="uid://fhriwlhm0lcj"]
 
 [ext_resource type="PackedScene" uid="uid://n83wlhmmsu3j" path="res://core/systems/input/input_manager.tscn" id="1_34t85"]
 [ext_resource type="Theme" uid="uid://ehplgpp70vxa" path="res://assets/themes/card_ui-dracula.tres" id="1_ajgj2"]
@@ -20,6 +20,7 @@
 [ext_resource type="PackedScene" uid="uid://jfacx7uys32r" path="res://core/ui/card_ui/main-menu/main_menu.tscn" id="13_46tck"]
 [ext_resource type="PackedScene" uid="uid://b30stcxjwk3od" path="res://core/ui/card_ui/ootbe/first_boot_menu.tscn" id="14_dpfu1"]
 [ext_resource type="PackedScene" uid="uid://hroo3ll4inrb" path="res://core/ui/card_ui/qam/quick_access_menu.tscn" id="14_lsaok"]
+[ext_resource type="PackedScene" uid="uid://dj1fooc3gh13l" path="res://core/ui/card_ui/help/help_menu.tscn" id="15_m1wp2"]
 [ext_resource type="PackedScene" uid="uid://cu4l0d1joc37w" path="res://core/ui/card_ui/navigation/in-game_notification.tscn" id="16_bcudw"]
 [ext_resource type="PackedScene" uid="uid://vf4sij64f82b" path="res://core/ui/vapor_ui/osk/on_screen_keyboard.tscn" id="18_462u5"]
 [ext_resource type="PackedScene" uid="uid://doft5r1y37j1" path="res://core/ui/components/volume_indicator.tscn" id="18_g4maw"]
@@ -140,6 +141,10 @@ visible = false
 layout_mode = 2
 
 [node name="FirstBootMenu" parent="MenuContent/AboveContextBarMargin" instance=ExtResource("14_dpfu1")]
+visible = false
+layout_mode = 2
+
+[node name="HelpMenu" parent="MenuContent/AboveContextBarMargin" instance=ExtResource("15_m1wp2")]
 visible = false
 layout_mode = 2
 

--- a/core/ui/card_ui/help/help_menu.gd
+++ b/core/ui/card_ui/help/help_menu.gd
@@ -1,0 +1,6 @@
+extends Control
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.

--- a/core/ui/card_ui/help/help_menu.tscn
+++ b/core/ui/card_ui/help/help_menu.tscn
@@ -1,0 +1,268 @@
+[gd_scene load_steps=14 format=3 uid="uid://dj1fooc3gh13l"]
+
+[ext_resource type="Script" path="res://core/ui/card_ui/help/help_menu.gd" id="1_7fti5"]
+[ext_resource type="PackedScene" uid="uid://orey8uxm7v6v" path="res://core/systems/state/visibility_manager.tscn" id="2_pli5u"]
+[ext_resource type="PackedScene" uid="uid://ccd4sw84h1qbc" path="res://core/systems/input/back_input_handler.tscn" id="3_effq8"]
+[ext_resource type="Resource" uid="uid://db5gbdl3xgwlq" path="res://assets/state/states/help_menu.tres" id="3_hidel"]
+[ext_resource type="PackedScene" uid="uid://b0cyl6fdqxevn" path="res://core/systems/input/scroller_joystick.tscn" id="5_uocjd"]
+[ext_resource type="PackedScene" uid="uid://dithv38oqgy58" path="res://core/ui/components/section_label.tscn" id="5_wfsen"]
+[ext_resource type="PackedScene" uid="uid://d0u3rsa5qpj57" path="res://core/ui/components/subsection_label.tscn" id="7_15bya"]
+[ext_resource type="Script" path="res://addons/controller_icons/objects/TextureRect.gd" id="9_hxxd2"]
+[ext_resource type="PackedScene" uid="uid://dci64so7q3y67" path="res://core/ui/components/shortcut_button_icon.tscn" id="10_tisgi"]
+[ext_resource type="Texture2D" uid="uid://jcc3t88rfxh0" path="res://addons/controller_icons/assets/xbox360/x.png" id="11_e30qo"]
+[ext_resource type="Texture2D" uid="uid://bufx8lu1tny4o" path="res://addons/controller_icons/assets/xbox360/b.png" id="12_3rby5"]
+[ext_resource type="Texture2D" uid="uid://dhhjoq01cc2oh" path="res://addons/controller_icons/assets/xbox360/lt.png" id="13_w7w1y"]
+[ext_resource type="Texture2D" uid="uid://d2qha4gd4x604" path="res://addons/controller_icons/assets/xbox360/rt.png" id="14_vxuc7"]
+
+[node name="HelpMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_7fti5")
+
+[node name="VisibilityManager" parent="." instance=ExtResource("2_pli5u")]
+state = ExtResource("3_hidel")
+
+[node name="BackInputHandler" parent="." instance=ExtResource("3_effq8")]
+process_input_during = Array[Resource("res://core/systems/state/state.gd")]([ExtResource("3_hidel")])
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = 120
+theme_override_constants/margin_top = 40
+theme_override_constants/margin_right = 120
+theme_override_constants/margin_bottom = 60
+
+[node name="PanelContainer" type="PanelContainer" parent="MarginContainer"]
+layout_mode = 2
+theme_type_variation = &"SettingsMenu"
+
+[node name="ScrollContainer" type="ScrollContainer" parent="MarginContainer/PanelContainer"]
+layout_mode = 2
+
+[node name="ScrollerJoystick" parent="MarginContainer/PanelContainer/ScrollContainer" instance=ExtResource("5_uocjd")]
+
+[node name="MarginContainer" type="MarginContainer" parent="MarginContainer/PanelContainer/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/margin_left = 30
+theme_override_constants/margin_top = 30
+theme_override_constants/margin_right = 30
+theme_override_constants/margin_bottom = 30
+
+[node name="HelpContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SectionLabel" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer" instance=ExtResource("5_wfsen")]
+layout_mode = 2
+text = "Help"
+horizontal_alignment = 1
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer"]
+layout_mode = 2
+theme_override_constants/separation = 60
+
+[node name="MenuShortcutsContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SubsectionLabel" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer" instance=ExtResource("7_15bya")]
+layout_mode = 2
+text = "Menu Shortcuts"
+
+[node name="HBoxContainer8" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer8"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Accept"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer8" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+keyboard_modifier = ""
+keyboard_key = "ui_accept"
+gamepad_modifier = ""
+
+[node name="HBoxContainer7" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer7"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Back"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer7" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+keyboard_modifier = ""
+keyboard_key = "ogui_east"
+gamepad_modifier = ""
+gamepad_button = "joypad/b"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Open Main Menu"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+gamepad_modifier = ""
+gamepad_button = "joypad/home"
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Open Quick Access Menu"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer2" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+keyboard_key = "key/f2"
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer3"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Open On-Screen Keyboard"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer3" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+keyboard_modifier = "joypad/home"
+keyboard_key = "joypad/x"
+gamepad_button = "joypad/x"
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer4"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Scroll container"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer4" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+keyboard_modifier = ""
+keyboard_key = "mouse/middle"
+gamepad_modifier = ""
+gamepad_button = "joypad/r_stick_click"
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer5"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Switch to left tab"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer5" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+keyboard_key = "key/page_up"
+gamepad_modifier = ""
+gamepad_button = "joypad/lb"
+
+[node name="HBoxContainer6" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer6"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Switch to right tab"
+
+[node name="ShortcutButtonIcon" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/MenuShortcutsContainer/HBoxContainer6" instance=ExtResource("10_tisgi")]
+layout_mode = 2
+keyboard_key = "key/page_down"
+gamepad_modifier = ""
+gamepad_button = "joypad/rb"
+
+[node name="OSKShortcutsContainer" type="VBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="SubsectionLabel" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer" instance=ExtResource("7_15bya")]
+layout_mode = 2
+text = "On-Screen Keyboard Shortcuts"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Backspace"
+
+[node name="QAMModifierIcon" type="TextureRect" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer"]
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+texture = ExtResource("11_e30qo")
+expand_mode = 1
+script = ExtResource("9_hxxd2")
+path = "joypad/x"
+force_type = 2
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer2"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Close keyboard"
+
+[node name="QAMModifierIcon" type="TextureRect" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer2"]
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+texture = ExtResource("12_3rby5")
+expand_mode = 1
+script = ExtResource("9_hxxd2")
+path = "joypad/b"
+force_type = 2
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer3"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Toggle Shift"
+
+[node name="QAMModifierIcon" type="TextureRect" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer3"]
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+texture = ExtResource("13_w7w1y")
+expand_mode = 1
+script = ExtResource("9_hxxd2")
+path = "joypad/lt"
+force_type = 2
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer4"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Enter"
+
+[node name="QAMModifierIcon" type="TextureRect" parent="MarginContainer/PanelContainer/ScrollContainer/MarginContainer/HelpContainer/HBoxContainer/OSKShortcutsContainer/HBoxContainer4"]
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+texture = ExtResource("14_vxuc7")
+expand_mode = 1
+script = ExtResource("9_hxxd2")
+path = "joypad/rt"
+force_type = 2

--- a/core/ui/card_ui/navigation/top_button_menu.tscn
+++ b/core/ui/card_ui/navigation/top_button_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://by0i08fw1fwty"]
+[gd_scene load_steps=13 format=3 uid="uid://by0i08fw1fwty"]
 
 [ext_resource type="Texture2D" uid="uid://bjscvn2us6tal" path="res://assets/ui/icons/bell.svg" id="1_te2kv"]
 [ext_resource type="Script" path="res://core/systems/state/visibility_manager.gd" id="1_ue0mf"]
@@ -11,6 +11,7 @@
 [ext_resource type="PackedScene" uid="uid://b76dvfuouhlwd" path="res://core/systems/state/state_updater.tscn" id="9_nhibw"]
 [ext_resource type="Resource" uid="uid://cr544el0cqjlm" path="res://assets/state/state_machines/global_state_machine.tres" id="10_5h6sh"]
 [ext_resource type="Resource" uid="uid://d3gp85f35oiw6" path="res://assets/state/states/settings.tres" id="11_eo1bd"]
+[ext_resource type="Resource" uid="uid://db5gbdl3xgwlq" path="res://assets/state/states/help_menu.tres" id="11_q3ls8"]
 
 [node name="ButtonMenu" type="PanelContainer"]
 z_index = 20
@@ -44,6 +45,11 @@ texture = ExtResource("1_te2kv")
 custom_minimum_size = Vector2(36, 36)
 layout_mode = 2
 texture = ExtResource("2_1q5o3")
+
+[node name="StateUpdater" parent="MarginContainer/HBoxContainer/HelpButton" instance=ExtResource("9_nhibw")]
+state_machine = ExtResource("10_5h6sh")
+state = ExtResource("11_q3ls8")
+on_signal = "button_up"
 
 [node name="SettingsButton" parent="MarginContainer/HBoxContainer" instance=ExtResource("6_b4g8u")]
 custom_minimum_size = Vector2(36, 36)

--- a/core/ui/card_ui/qam/quick_access_menu.tscn
+++ b/core/ui/card_ui/qam/quick_access_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=26 format=3 uid="uid://hroo3ll4inrb"]
+[gd_scene load_steps=27 format=3 uid="uid://hroo3ll4inrb"]
 
 [ext_resource type="Script" path="res://core/ui/card_ui/qam/quick_access_menu.gd" id="1_56jo7"]
 [ext_resource type="Script" path="res://core/systems/state/visibility_manager.gd" id="2_s7f3g"]
@@ -14,11 +14,12 @@
 [ext_resource type="PackedScene" uid="uid://b76dvfuouhlwd" path="res://core/systems/state/state_updater.tscn" id="12_ldp5y"]
 [ext_resource type="Resource" uid="uid://cr544el0cqjlm" path="res://assets/state/state_machines/global_state_machine.tres" id="13_u3r8o"]
 [ext_resource type="Resource" uid="uid://d3gp85f35oiw6" path="res://assets/state/states/settings.tres" id="14_didkb"]
+[ext_resource type="Resource" uid="uid://db5gbdl3xgwlq" path="res://assets/state/states/help_menu.tres" id="14_gr3i0"]
 [ext_resource type="PackedScene" uid="uid://dithv38oqgy58" path="res://core/ui/components/section_label.tscn" id="15_ip4q6"]
 [ext_resource type="Texture2D" uid="uid://djy4rejy21s6g" path="res://icon.svg" id="16_5eydp"]
 [ext_resource type="PackedScene" uid="uid://b0cyl6fdqxevn" path="res://core/systems/input/scroller_joystick.tscn" id="17_qgen2"]
 [ext_resource type="Resource" uid="uid://dpc1o781f43ef" path="res://core/ui/card_ui/qam/quick_access_menu_focus.tres" id="18_4nxly"]
-[ext_resource type="PackedScene" path="res://core/ui/card_ui/qam/notifications_card.tscn" id="19_pppbi"]
+[ext_resource type="PackedScene" uid="uid://bjy50kdrebgre" path="res://core/ui/card_ui/qam/notifications_card.tscn" id="19_pppbi"]
 [ext_resource type="PackedScene" uid="uid://dxaeufuk7ump2" path="res://core/ui/card_ui/qam/quick_settings_card.tscn" id="20_17ks0"]
 [ext_resource type="PackedScene" uid="uid://dycb7m0oj13ly" path="res://core/ui/card_ui/qam/performance_card.tscn" id="21_uw510"]
 [ext_resource type="PackedScene" uid="uid://v751ima8r8vg" path="res://core/ui/card_ui/qam/power_tools_card.tscn" id="22_dtanu"]
@@ -162,6 +163,11 @@ texture = ExtResource("10_4yppf")
 custom_minimum_size = Vector2(26, 26)
 layout_mode = 2
 texture = ExtResource("11_a0ma3")
+
+[node name="StateUpdater" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer/HelpButton" instance=ExtResource("12_ldp5y")]
+state_machine = ExtResource("13_u3r8o")
+state = ExtResource("14_gr3i0")
+on_signal = "button_up"
 
 [node name="Spacer" type="Control" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ButtonContainer"]
 layout_mode = 2

--- a/core/ui/components/shortcut_button_icon.gd
+++ b/core/ui/components/shortcut_button_icon.gd
@@ -1,0 +1,37 @@
+@tool
+extends HBoxContainer
+class_name ControllerShortcutIcon
+
+@export_category("Keyboard")
+@export var keyboard_modifier := "key/ctrl"
+@export var keyboard_key := "key/f1"
+@export_category("Gamepad")
+@export var gamepad_modifier := "joypad/home"
+@export var gamepad_button := "joypad/a"
+
+
+@onready var modifier_icon := $%ModifierIcon as ControllerTextureRect
+@onready var plus_label := $%PlusLabel as Label
+@onready var button_icon := $%ButtonIcon as ControllerTextureRect
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	_on_input_type_changed(ControllerIcons.InputType.KEYBOARD_MOUSE)
+	ControllerIcons.input_type_changed.connect(_on_input_type_changed)
+
+
+# Update the icons in the context bar based on input type
+func _on_input_type_changed(input_type: ControllerIcons.InputType) -> void:
+	if input_type == ControllerIcons.InputType.CONTROLLER:
+		modifier_icon.visible = gamepad_modifier != ""
+		plus_label.visible = gamepad_modifier != ""
+		modifier_icon.path = gamepad_modifier
+		button_icon.path = gamepad_button
+		return
+
+	# Keyboard/mouse input type
+	modifier_icon.visible = keyboard_modifier != ""
+	plus_label.visible = keyboard_modifier != ""
+	modifier_icon.path = keyboard_modifier
+	button_icon.path = keyboard_key

--- a/core/ui/components/shortcut_button_icon.tscn
+++ b/core/ui/components/shortcut_button_icon.tscn
@@ -1,0 +1,35 @@
+[gd_scene load_steps=5 format=3 uid="uid://dci64so7q3y67"]
+
+[ext_resource type="Script" path="res://core/ui/components/shortcut_button_icon.gd" id="1_0pf4u"]
+[ext_resource type="Texture2D" uid="uid://dxcfr4bhfw4lq" path="res://addons/controller_icons/assets/key/ctrl.png" id="2_hyqpc"]
+[ext_resource type="Script" path="res://addons/controller_icons/objects/TextureRect.gd" id="2_p81n3"]
+[ext_resource type="Texture2D" uid="uid://b8no45t86rrn6" path="res://addons/controller_icons/assets/key/f1.png" id="3_s205v"]
+
+[node name="ShortcutButtonIcon" type="HBoxContainer"]
+offset_right = 98.0
+offset_bottom = 40.0
+script = ExtResource("1_0pf4u")
+
+[node name="ModifierIcon" type="TextureRect" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+texture = ExtResource("2_hyqpc")
+expand_mode = 1
+script = ExtResource("2_p81n3")
+path = "key/ctrl"
+force_type = 2
+
+[node name="PlusLabel" type="Label" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+text = "+"
+
+[node name="ButtonIcon" type="TextureRect" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(40, 40)
+layout_mode = 2
+texture = ExtResource("3_s205v")
+expand_mode = 1
+script = ExtResource("2_p81n3")
+path = "key/f1"


### PR DESCRIPTION
This change adds a help menu with interface shortcuts.

![image](https://github.com/ShadowBlip/OpenGamepadUI/assets/376460/cb5742fc-be4e-4da3-90e2-7d542232e20a)
