### PR TITLE
Refactor update system to launch full binary updates

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -47,7 +47,6 @@ plugins:
       - path: dist/opengamepadui.raw.sha256.txt
       - path: dist/opengamepadui.tar.gz
       - path: dist/opengamepadui.tar.gz.sha256.txt
-      - path: dist/update.pck
-      - path: dist/update.pck.sha256.txt
-      - path: dist/update.pck.sig
+      - path: dist/update.zip
+      - path: dist/update.zip.sha256.txt
       - path: docs/install/opengamepadui_deck_installer.desktop

--- a/Makefile
+++ b/Makefile
@@ -271,11 +271,10 @@ rootfs: build/opengamepad-ui.x86_64
 
 
 .PHONY: dist 
-dist: dist/opengamepadui.tar.gz dist/opengamepadui.raw dist/update.zip dist/update.pck.sig ## Create all redistributable versions of the project
+dist: dist/opengamepadui.tar.gz dist/opengamepadui.raw dist/update.zip ## Create all redistributable versions of the project
 	cd dist && sha256sum opengamepadui.tar.gz > opengamepadui.tar.gz.sha256.txt
-	cd dist && sha256sum update.zip > update.zip.sha256.txt
-	cd dist && sha256sum update.pck > update.pck.sha256.txt
 	cd dist && sha256sum opengamepadui.raw > opengamepadui.raw.sha256.txt
+	cd dist && sha256sum update.zip > update.zip.sha256.txt
 
 
 .PHONY: dist-archive
@@ -294,7 +293,8 @@ dist-update-zip: dist/update.zip ## Create an update zip archive
 dist/update.zip: build/metadata.json
 	@echo "Building redistributable update zip"
 	mkdir -p $(CACHE_DIR)
-	cd build && zip -9 ../$(CACHE_DIR)/update *.so opengamepad-ui.* metadata.json
+	rm -rf $(CACHE_DIR)/update.zip
+	cd build && zip -5 ../$(CACHE_DIR)/update *.so opengamepad-ui.* metadata.json
 	mkdir -p dist
 	cp $(CACHE_DIR)/update.zip $@
 

--- a/Makefile
+++ b/Makefile
@@ -118,15 +118,18 @@ build/metadata.json: build/opengamepad-ui.x86_64 assets/crypto/keys/opengamepadu
 	for lib in `ls *.so`; do \
 		echo "Signing file: $$lib"; \
 		SIG=$$(openssl dgst -sha256 -sign ../assets/crypto/keys/opengamepadui.key $$lib | base64 -w 0); \
-		FILE_SIGS="$$FILE_SIGS\"$$lib\": \"$$SIG\", "; \
+		HASH=$$(sha256sum $$lib | cut -d' ' -f1); \
+		FILE_SIGS="$$FILE_SIGS\"$$lib\": {\"signature\": \"$$SIG\", \"hash\": \"$$HASH\"}, "; \
 	done; \
 	# Sign the binary files \
 	echo "Signing file: opengamepad-ui.sh"; \
 	SIG=$$(openssl dgst -sha256 -sign ../assets/crypto/keys/opengamepadui.key opengamepad-ui.sh | base64 -w 0); \
-	FILE_SIGS="$$FILE_SIGS\"opengamepad-ui.sh\": \"$$SIG\", "; \
+	HASH=$$(sha256sum opengamepad-ui.sh | cut -d' ' -f1); \
+	FILE_SIGS="$$FILE_SIGS\"opengamepad-ui.sh\": {\"signature\": \"$$SIG\", \"hash\": \"$$HASH\"}, "; \
 	echo "Signing file: opengamepad-ui.x86_64"; \
 	SIG=$$(openssl dgst -sha256 -sign ../assets/crypto/keys/opengamepadui.key opengamepad-ui.x86_64 | base64 -w 0); \
-	FILE_SIGS="$$FILE_SIGS\"opengamepad-ui.x86_64\": \"$$SIG\"}"; \
+	HASH=$$(sha256sum opengamepad-ui.x86_64 | cut -d' ' -f1); \
+	FILE_SIGS="$$FILE_SIGS\"opengamepad-ui.x86_64\": {\"signature\": \"$$SIG\", \"hash\": \"$$HASH\"}}"; \
 	# Write out the signatures to metadata.json \
 	echo "{\"version\": \"$(OGUI_VERSION)\", \"engine_version\": \"$(GODOT_REVISION)\", \"files\": $$FILE_SIGS}" > metadata.json
 

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,12 @@ deploy: dist-archive $(SSH_MOUNT_PATH)/.mounted ## Build, deploy, and tunnel to 
 	cd $(SSH_MOUNT_PATH) && tar xvfz opengamepadui.tar.gz
 
 
+.PHONY: deploy-update
+deploy-update: dist/update.zip ## Build and deploy update zip to remote device
+	ssh $(SSH_USER)@$(SSH_HOST) mkdir -p .local/share/opengamepadui/updates
+	scp dist/update.zip $(SSH_USER)@$(SSH_HOST):~/.local/share/opengamepadui/updates
+
+
 .PHONY: deploy-pack
 deploy-pack: dist/update.pck.sig ## Build and deploy update pack to remote device (DEPRECATED)
 	ssh $(SSH_USER)@$(SSH_HOST) mkdir -p .local/share/opengamepadui/updates

--- a/core/systems/crypto/package_verifier.gd
+++ b/core/systems/crypto/package_verifier.gd
@@ -48,3 +48,18 @@ func get_hash(data: PackedByteArray, type: HashingContext.HashType = HashingCont
 ## Get the hash of the given data as a hex encoded string
 func get_hash_string(data: PackedByteArray, type: HashingContext.HashType = HashingContext.HASH_SHA256) -> String:
 	return get_hash(data, type).hex_encode()
+
+
+## Returns the hash of the file at the given path
+func get_file_hash(path: String, type: HashingContext.HashType = HashingContext.HASH_SHA256) -> PackedByteArray:
+	if not FileAccess.file_exists(path):
+		logger.warn("File does not exist at path: " + path)
+		return PackedByteArray()
+	var data := FileAccess.get_file_as_bytes(path)
+	
+	return get_hash(data, type)
+
+
+## Get the hash of the file at the given path as a hex encoded string
+func get_file_hash_string(path: String, type: HashingContext.HashType = HashingContext.HASH_SHA256) -> String:
+	return get_file_hash(path, type).hex_encode()

--- a/entrypoint.gd
+++ b/entrypoint.gd
@@ -1,22 +1,27 @@
 extends Node
 
-const update_pack_file := "user://updates/update.pck"
-const signature_file := "user://updates/update.pck.sig"
+const updates_path := "user://updates"
+const update_pack_file := "user://updates/update.zip"
+const update_pack_entrypoint := "user://updates/opengamepad-ui.x86_64"
 
 var PackageVerifier := preload("res://core/global/package_verifier.tres") as PackageVerifier
 var args := OS.get_cmdline_args()
 var logger := Log.get_logger("Entrypoint")
 
+func _init() -> void:
+	var version := load("res://core/global/version.tres") as Version
+	print("OpenGamepadUI v", version.core)
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
-	get_tree().get_root().transparent_bg = true
-	var version := load("res://core/global/version.tres") as Version
-	print("OpenGamepadUI v", version.core)
+	var window := get_viewport()
+	window.transparent_bg = true
 	
 	# Apply any update packs
-	_apply_update_packs()
-
+	if not "--skip-update-pack" in args:
+		_apply_update_packs()
+	
 	# Launch the main interface
 	get_tree().change_scene_to_file("res://core/main.tscn")
 	
@@ -29,23 +34,87 @@ func _apply_update_packs() -> void:
 		return
 	logger.info("Update pack was found.")
 	
-	# Validate the signature on the update pack.
-	if "--skip-verify-packages" in args:
+	# Check if we should validate update archive signatures
+	var verify_signatures := not "--skip-verify-packages" in args
+	if not verify_signatures:
 		logger.warn("Skipping validation of update pack. This could be dangerous!")
-	else:
-		if not FileAccess.file_exists(signature_file):
-			logger.warn("Unable to find signature file for update pack. Not loading update pack.")
-			return
-		var signature := FileAccess.get_file_as_bytes(signature_file)
-		if not PackageVerifier.file_has_valid_signature(update_pack_file, signature):
-			logger.warn("Update pack does not have a valid signature! Not loading update pack.")
-			return
+
+	# Read the metadata from the update zip
+	var reader := ZIPReader.new()
+	if reader.open(update_pack_file) != OK:
+		logger.warn("Unable to read update pack file. Not loading update pack.")
+		return
+	var metadata := reader.read_file("metadata.json")
+	if metadata.size() == 0:
+		logger.warn("Unable to read metadata.json from update pack.")
+		return
 	
-	# Load the update pack
-	if ProjectSettings.load_resource_pack(update_pack_file):
-		logger.info("Update pack loaded successfully")
-		var version := ResourceLoader.load("res://core/global/version.tres", "", ResourceLoader.CACHE_MODE_IGNORE) as Version
-		version.take_over_path("res://core/global/version.tres")
-		print("OpenGamepadUI Update Pack v", version.core)
-	else:
-		logger.warn("Failed to load update pack")
+	# Parse the metadata from the zip file
+	var parsed_metadata = JSON.parse_string(metadata.get_string_from_ascii())
+	if not parsed_metadata is Dictionary:
+		logger.warn("Unable to parse metadata.json")
+		return
+	if not "version" in parsed_metadata:
+		logger.warn("No version found in metadata.json")
+		return
+	if not "files" in parsed_metadata:
+		logger.warn("No files list found in metadata.json")
+		return
+	logger.info("Update pack version: " + parsed_metadata["version"])
+	
+	# Check if the update pack is a newer version than our version
+	var version := load("res://core/global/version.tres") as Version
+	if not SemanticVersion.is_greater_or_equal(version.core, parsed_metadata["version"]):
+		logger.info("Update pack version is older than base version")
+		return
+	
+	# Validate and extract each file in the update pack
+	var files := parsed_metadata["files"] as Dictionary
+	for filename in files.keys():
+		var file_data := reader.read_file(filename)
+		var hash := files[filename]["hash"] as String
+		var sig_b64 := files[filename]["signature"] as String
+		var sig := Marshalls.base64_to_raw(sig_b64)
+
+		# Validate the file signatures
+		if verify_signatures:
+			if not PackageVerifier.has_valid_signature(file_data, sig):
+				logger.warn("File " + filename + " in update.zip does not have a valid signature. Not loading update pack.")
+				return
+		
+		# Validate the hash defined in the metadata
+		if PackageVerifier.get_hash_string(file_data) != hash:
+			logger.warn("File " + filename + " in update.zip does not have a valid hash. Not loading update pack.")
+			return
+
+		# Check to see if this file is already extracted
+		var extracted_path := "/".join([updates_path, filename])
+		if FileAccess.file_exists(extracted_path):
+			logger.debug("File already exists: " + extracted_path)
+			var extracted_hash := PackageVerifier.get_file_hash_string(extracted_path)
+			if extracted_hash == hash:
+				logger.debug("File hash matches, skipping")
+				continue
+	
+		# Write the extracted file from the update pack
+		var extracted_file := FileAccess.open(extracted_path, FileAccess.WRITE_READ)
+		extracted_file.store_buffer(file_data)
+		extracted_file.flush()
+		extracted_file.close()
+		
+		# Set execute permissions
+		if filename == "opengamepad-ui.x86_64":
+			var file_path := ProjectSettings.globalize_path(extracted_path)
+			if OS.execute("chmod", ["+x", file_path]) != OK:
+				logger.warn("Failed to set execute permissions. Not loading update pack")
+				return
+
+	# Launch the update pack executable and exit
+	var update_bin := ProjectSettings.globalize_path(update_pack_entrypoint)
+	var update_args := PackedStringArray([update_bin])
+	update_args.append_array(OS.get_cmdline_args())
+	update_args.append("--skip-update-pack")
+	logger.info("Launching update pack: " + " ".join(update_args))
+	var code := OS.execute("exec", update_args)
+	logger.info("Child exited")
+	get_tree().quit(code)

--- a/entrypoint.gd
+++ b/entrypoint.gd
@@ -118,7 +118,7 @@ func _apply_update_packs() -> void:
 				continue
 	
 		# Write the extracted file from the update pack
-		var extracted_file := FileAccess.open(extracted_path, FileAccess.WRITE_READ)
+		var extracted_file := FileAccess.open(extracted_path, FileAccess.WRITE)
 		extracted_file.store_buffer(file_data)
 		extracted_file.flush()
 		extracted_file.close()


### PR DESCRIPTION
This change refactors the update system to use full binary archives instead of using Godot resource packs. This has some advantages:

* It allows updates to include new GDExtension native libraries when using the updater.
* It allows updates to use a newer Godot Engine build of OpenGamepadUI.
* It resolves some bugs we've seen with resource packs where the class definitions are not parsed correctly.

The new update system includes a way to create an "update zip" when you run `make dist-update-zip`. Invoking this target will build the project and create a `metadata.json` file with the hashes and signatures of all files in the update and zip them up.

When OpenGamepadUI launches, it looks for an update in `~/.local/share/opengamepadui/updates/update.zip`. If it finds one, it will read the `metadata.json` file and validate the signatures and hashes of the update, then unzip them and launch the executable inside.