### PR TITLE
fix(Platform): Add ROG Ally

### DIFF
--- a/core/global/platform.gd
+++ b/core/global/platform.gd
@@ -81,7 +81,6 @@ func _init() -> void:
 	intel_apu_database = load("res://core/platform/hardware/intel_apu_database.tres")
 	amd_apu_database.init()
 	intel_apu_database.init()
-	_get_system_components()
 
 	var flags := get_platform_flags()
 	
@@ -128,6 +127,8 @@ func _init() -> void:
 		os = load("res://core/platform/steamos.tres")
 	if PLATFORM.CHIMERAOS in flags:
 		os = load("res://core/platform/chimeraos.tres")
+
+	_get_system_components()
 
 
 ## Loads the detected platforms. This should be called once when OpenGamepadUI
@@ -384,8 +385,8 @@ func _read_gpu_info() -> GPUInfo:
 			gpu_info.model = str(" ".join(parts))
 	logger.debug("Found GPU: Vendor: " + gpu_info.vendor + "Model: " + gpu_info.model)
 
-	if FileAccess.file_exists("/sys/devices/platform/asus-nb-wmi/throttle_thermal_policy"):
-		logger.debug("Thermal Throttle Capable!")
+	if "thermal_policy_path" in platform and FileAccess.file_exists(platform.thermal_policy_path):
+		logger.debug("Platform able to set thermal policy")
 		gpu_info.thermal_mode_capable = true
 
 	if not cpu:

--- a/core/platform/ally_gen1.gd
+++ b/core/platform/ally_gen1.gd
@@ -1,0 +1,7 @@
+extends PlatformProvider
+class_name PlatformAllyGen1
+
+
+func get_handheld_gamepad() -> HandheldGamepad:
+	logger.info("Using Ally Gen 1 platform configuration.")
+	return load("res://core/platform/ally_gen1_gamepad.tres")

--- a/core/platform/ally_gen1.gd
+++ b/core/platform/ally_gen1.gd
@@ -1,6 +1,7 @@
 extends PlatformProvider
 class_name PlatformAllyGen1
 
+@export var thermal_policy_path: String = "/sys/devices/platform/asus-nb-wmi/throttle_thermal_policy"
 
 func get_handheld_gamepad() -> HandheldGamepad:
 	logger.info("Using Ally Gen 1 platform configuration.")

--- a/core/platform/ally_gen1.tres
+++ b/core/platform/ally_gen1.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Resource" script_class="PlatformAllyGen1" load_steps=2 format=3 uid="uid://dy81o102wj6j5"]
+
+[ext_resource type="Script" path="res://core/platform/ally_gen1.gd" id="1_rib2o"]
+
+[resource]
+script = ExtResource("1_rib2o")
+name = ""

--- a/core/platform/ally_gen1.tres
+++ b/core/platform/ally_gen1.tres
@@ -4,4 +4,5 @@
 
 [resource]
 script = ExtResource("1_rib2o")
-name = ""
+thermal_policy_path = "/sys/devices/platform/asus-nb-wmi/throttle_thermal_policy"
+name = "ROG Ally"

--- a/core/platform/ally_gen1_gamepad.tres
+++ b/core/platform/ally_gen1_gamepad.tres
@@ -1,0 +1,119 @@
+[gd_resource type="Resource" script_class="HandheldGamepad" load_steps=22 format=3 uid="uid://u8f26awy1m8x"]
+
+[ext_resource type="Script" path="res://core/platform/mapped_event.gd" id="1_x4ifc"]
+[ext_resource type="Script" path="res://core/systems/input/handheld_gamepad.gd" id="2_ywgkw"]
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_lxa7u"]
+type = 1
+code = 68
+value = 1
+
+[sub_resource type="Resource" id="Resource_egstq"]
+script = ExtResource("1_x4ifc")
+activation_keys = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_lxa7u")])
+event_list = Array[InputDeviceEvent]([])
+ogui_event = "ogui_osk"
+on_release = false
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_3lfhm"]
+type = 1
+code = 88
+value = 1
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_qccdh"]
+type = 1
+code = 316
+value = 1
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_dwoox"]
+type = 1
+code = 307
+value = 1
+
+[sub_resource type="Resource" id="Resource_qumy2"]
+script = ExtResource("1_x4ifc")
+activation_keys = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_3lfhm")])
+event_list = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_qccdh"), SubResource("InputDeviceEvent_dwoox")])
+ogui_event = ""
+on_release = false
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_cnrcv"]
+type = 1
+code = 148
+value = 1
+
+[sub_resource type="Resource" id="Resource_6mg1t"]
+script = ExtResource("1_x4ifc")
+activation_keys = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_cnrcv")])
+event_list = Array[InputDeviceEvent]([])
+ogui_event = "ogui_qam"
+on_release = false
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_8lcui"]
+type = 1
+code = 184
+value = 1
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_omr05"]
+type = 1
+code = 316
+value = 1
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_vsd2u"]
+type = 1
+code = 311
+value = 1
+
+[sub_resource type="Resource" id="Resource_j2gqt"]
+script = ExtResource("1_x4ifc")
+activation_keys = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_8lcui")])
+event_list = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_omr05"), SubResource("InputDeviceEvent_vsd2u")])
+ogui_event = ""
+on_release = false
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_f3y1k"]
+type = 1
+code = 186
+value = 1
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_re26x"]
+type = 1
+code = 316
+value = 1
+
+[sub_resource type="Resource" id="Resource_d37ji"]
+script = ExtResource("1_x4ifc")
+activation_keys = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_f3y1k")])
+event_list = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_re26x")])
+ogui_event = ""
+on_release = false
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_lmnpc"]
+type = 1
+code = 187
+value = 1
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_5csyo"]
+type = 1
+code = 316
+value = 1
+
+[sub_resource type="InputDeviceEvent" id="InputDeviceEvent_5judj"]
+type = 1
+code = 304
+value = 1
+
+[sub_resource type="Resource" id="Resource_kh6ar"]
+script = ExtResource("1_x4ifc")
+activation_keys = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_lmnpc")])
+event_list = Array[InputDeviceEvent]([SubResource("InputDeviceEvent_5csyo"), SubResource("InputDeviceEvent_5judj")])
+ogui_event = ""
+on_release = false
+
+[resource]
+script = ExtResource("2_ywgkw")
+mapped_events = Array[ExtResource("1_x4ifc")]([SubResource("Resource_egstq"), SubResource("Resource_qumy2"), SubResource("Resource_6mg1t"), SubResource("Resource_j2gqt"), SubResource("Resource_d37ji"), SubResource("Resource_kh6ar")])
+kb_phys_path = "usb-0000:0a:00.3-3/input2"
+kb_phys_name = "Asus Keyboard"
+gamepad_phys_path = "usb-0000:0a:00.3-2/input0"
+gamepad_phys_name = "Microsoft X-Box 360 pad"

--- a/core/platform/hardware/amd_apu_database.tres
+++ b/core/platform/hardware/amd_apu_database.tres
@@ -435,7 +435,7 @@ script = ExtResource("1_a4rxd")
 model_name = "AMD Ryzen 7 7840U with Radeon Graphics"
 min_tdp = 5.0
 max_tdp = 35.0
-max_boost = 37.0
+max_boost = 5.0
 
 [resource]
 script = ExtResource("2_pbguw")

--- a/core/platform/hardware/amd_apu_database.tres
+++ b/core/platform/hardware/amd_apu_database.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="APUDatabase" load_steps=63 format=3 uid="uid://hm5433bg4nrm"]
+[gd_resource type="Resource" script_class="APUDatabase" load_steps=65 format=3 uid="uid://hm5433bg4nrm"]
 
 [ext_resource type="Script" path="res://core/platform/hardware/apu_entry.gd" id="1_a4rxd"]
 [ext_resource type="Script" path="res://core/platform/hardware/apu_database.gd" id="2_pbguw"]
@@ -423,7 +423,21 @@ min_tdp = 6.0
 max_tdp = 10.0
 max_boost = 2.0
 
+[sub_resource type="Resource" id="Resource_u78ox"]
+script = ExtResource("1_a4rxd")
+model_name = "AMD Ryzen Z1 Extreme"
+min_tdp = 5.0
+max_tdp = 35.0
+max_boost = 5.0
+
+[sub_resource type="Resource" id="Resource_vyhi3"]
+script = ExtResource("1_a4rxd")
+model_name = "AMD Ryzen 7 7840U with Radeon Graphics"
+min_tdp = 5.0
+max_tdp = 35.0
+max_boost = 37.0
+
 [resource]
 script = ExtResource("2_pbguw")
-apu_list = Array[ExtResource("1_a4rxd")]([SubResource("Resource_wio8w"), SubResource("Resource_tcfff"), SubResource("Resource_wmno8"), SubResource("Resource_b8fpu"), SubResource("Resource_1g34g"), SubResource("Resource_sp41q"), SubResource("Resource_h2si0"), SubResource("Resource_0pmlr"), SubResource("Resource_y8ihm"), SubResource("Resource_bvqtb"), SubResource("Resource_rk6b7"), SubResource("Resource_lnxua"), SubResource("Resource_0u6yf"), SubResource("Resource_6f80n"), SubResource("Resource_lbrm0"), SubResource("Resource_t5d1l"), SubResource("Resource_pnxln"), SubResource("Resource_e6tev"), SubResource("Resource_u52m2"), SubResource("Resource_uwui8"), SubResource("Resource_2ks23"), SubResource("Resource_yv37b"), SubResource("Resource_pwp6g"), SubResource("Resource_chr8q"), SubResource("Resource_2pyvv"), SubResource("Resource_3lvxu"), SubResource("Resource_rct3m"), SubResource("Resource_pps3c"), SubResource("Resource_5xvvv"), SubResource("Resource_pseh1"), SubResource("Resource_b2c3r"), SubResource("Resource_q76ve"), SubResource("Resource_xjgl8"), SubResource("Resource_n363j"), SubResource("Resource_bq0w7"), SubResource("Resource_5k7fn"), SubResource("Resource_msyku"), SubResource("Resource_8qb0g"), SubResource("Resource_ynh34"), SubResource("Resource_b6xme"), SubResource("Resource_soogm"), SubResource("Resource_t80ob"), SubResource("Resource_8p12x"), SubResource("Resource_duhig"), SubResource("Resource_20afn"), SubResource("Resource_cc6u3"), SubResource("Resource_fja1l"), SubResource("Resource_fmue3"), SubResource("Resource_wdxra"), SubResource("Resource_6o1lg"), SubResource("Resource_s24u0"), SubResource("Resource_nn84a"), SubResource("Resource_n0x5x"), SubResource("Resource_rj5oh"), SubResource("Resource_jnmf4"), SubResource("Resource_6crrv"), SubResource("Resource_a0hyt"), SubResource("Resource_4nd4h"), SubResource("Resource_fyb6g"), SubResource("Resource_bw227")])
+apu_list = Array[ExtResource("1_a4rxd")]([SubResource("Resource_wio8w"), SubResource("Resource_tcfff"), SubResource("Resource_wmno8"), SubResource("Resource_b8fpu"), SubResource("Resource_1g34g"), SubResource("Resource_sp41q"), SubResource("Resource_h2si0"), SubResource("Resource_0pmlr"), SubResource("Resource_y8ihm"), SubResource("Resource_bvqtb"), SubResource("Resource_rk6b7"), SubResource("Resource_lnxua"), SubResource("Resource_0u6yf"), SubResource("Resource_6f80n"), SubResource("Resource_lbrm0"), SubResource("Resource_t5d1l"), SubResource("Resource_pnxln"), SubResource("Resource_e6tev"), SubResource("Resource_u52m2"), SubResource("Resource_uwui8"), SubResource("Resource_2ks23"), SubResource("Resource_yv37b"), SubResource("Resource_pwp6g"), SubResource("Resource_chr8q"), SubResource("Resource_2pyvv"), SubResource("Resource_3lvxu"), SubResource("Resource_rct3m"), SubResource("Resource_pps3c"), SubResource("Resource_5xvvv"), SubResource("Resource_pseh1"), SubResource("Resource_b2c3r"), SubResource("Resource_q76ve"), SubResource("Resource_xjgl8"), SubResource("Resource_n363j"), SubResource("Resource_bq0w7"), SubResource("Resource_5k7fn"), SubResource("Resource_msyku"), SubResource("Resource_8qb0g"), SubResource("Resource_ynh34"), SubResource("Resource_b6xme"), SubResource("Resource_soogm"), SubResource("Resource_t80ob"), SubResource("Resource_8p12x"), SubResource("Resource_duhig"), SubResource("Resource_20afn"), SubResource("Resource_cc6u3"), SubResource("Resource_fja1l"), SubResource("Resource_fmue3"), SubResource("Resource_wdxra"), SubResource("Resource_6o1lg"), SubResource("Resource_s24u0"), SubResource("Resource_nn84a"), SubResource("Resource_n0x5x"), SubResource("Resource_rj5oh"), SubResource("Resource_jnmf4"), SubResource("Resource_6crrv"), SubResource("Resource_a0hyt"), SubResource("Resource_4nd4h"), SubResource("Resource_fyb6g"), SubResource("Resource_bw227"), SubResource("Resource_u78ox"), SubResource("Resource_vyhi3")])
 database_name = "Intel"

--- a/core/systems/input/handheld_gamepad.gd
+++ b/core/systems/input/handheld_gamepad.gd
@@ -57,12 +57,14 @@ func process_input() -> void:
 			continue
 		if not _process_event(event):
 			stop_after_process = true
-	# If no keys are active we can stop here.
-	if stop_after_process:
-		return
-	if active_keys.size() == 0:
-		return
-	_check_mapped_events()
+		# If no keys are active we can stop here.
+		if stop_after_process:
+			logger.debug("We were told to stop after process")
+			continue
+		if active_keys.size() == 0:
+			logger.debug("No active keys")
+			continue
+		_check_mapped_events()
 
 
 ## Called to handle an individual event. Sets the active keys.

--- a/core/ui/vapor_ui/qam/powertools_menu.tscn
+++ b/core/ui/vapor_ui/qam/powertools_menu.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3]
+[gd_scene load_steps=8 format=3 uid="uid://dv3dt0j3jketh"]
 
 [ext_resource type="Script" path="res://core/ui/vapor_ui/qam/powertools_menu.gd" id="1_8v1ke"]
 [ext_resource type="PackedScene" uid="uid://d1qb7euwlu7bh" path="res://core/ui/components/toggle.tscn" id="2_nb5h3"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://8m20p2s0v5gb" path="res://core/systems/input/focus_group.tscn" id="3_5n8hq"]
 [ext_resource type="PackedScene" uid="uid://dithv38oqgy58" path="res://core/ui/components/section_label.tscn" id="3_v2d1e"]
 [ext_resource type="Resource" uid="uid://dpc1o781f43ef" path="res://core/ui/card_ui/qam/quick_access_menu_focus.tres" id="4_yqywg"]
+[ext_resource type="PackedScene" uid="uid://xei5afwefxud" path="res://core/ui/components/dropdown.tscn" id="7_4faqm"]
 
 [node name="PowerTools" type="VBoxContainer"]
 anchors_preset = 15
@@ -133,6 +134,12 @@ focus_previous = NodePath("../GPUFreqMinSlider")
 text = "Max Freq"
 max_value = 0.0
 step = 100.0
+
+[node name="ThermalProfileDropdown" parent="." instance=ExtResource("7_4faqm")]
+visible = false
+layout_mode = 2
+title = "Thermal Throttle Profile"
+description = ""
 
 [node name="GPUTempSlider" parent="." instance=ExtResource("2_ygeel")]
 visible = false

--- a/rootfs/usr/lib/udev/hwdb.d/59-opengamepadui-handheld.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/59-opengamepadui-handheld.hwdb
@@ -6,6 +6,10 @@ evdev:name:AT Translated Set 2 keyboard:dmi:*:svnAbernic:*
 evdev:name:AT Translated Set 2 keyboard:dmi:*:svnAOKZOE:*
   FORCE_INPUT_UACCESS=1
 
+## ASUS DEVICES
+evdev:name:Asus Keyboard:*:svnASUSTeKCOMPUTERINC.:pnROGAllyRC71L_RC71L:*
+  FORCE_INPUT_UACCESS=1
+
 ## AYANEO DEVICES
 evdev:name:AT Translated Set 2 keyboard:dmi:*:svnAYA NEO:*
   FORCE_INPUT_UACCESS=1

--- a/rootfs/usr/share/opengamepadui/scripts/powertools
+++ b/rootfs/usr/share/opengamepadui/scripts/powertools
@@ -46,6 +46,10 @@ setAmdPerfLevelWrite() { # set power_dpm_force_performace_level write
   /usr/bin/chmod a+w /sys/class/drm/card0/device/power_dpm_force_performance_level
 }
 
+setThermalPolicy(){
+  /usr/bin/echo $1 > /sys/devices/platform/asus-nb-wmi/throttle_thermal_policy
+}
+
 ## INTEL iGPU
 setRapl(){ #TDP Control
   /usr/bin/echo $1 > /sys/class/powercap/intel-rapl/intel-rapl:0/gt_min_freq_mhz
@@ -94,4 +98,7 @@ elif [[ $1 == "setRapl" ]]; then
 elif [[ $1 == "intelGpuClock" ]]; then
   intelGpuClock $2 $3
 
+## ASUS Specific
+elif [[ $1 == "setThermalPolicy" ]]; then
+  setThermalPolicy $2
 fi


### PR DESCRIPTION
- Adds ROG Platform.
- Adds Z1 Extreme APU.
- Adds Ryzen 7 7840U APU.
- Adds Thermal Profile Selector for ASUS devices with the thermal profile file descriptor.
- APU's that cannot read `ryzenadj -i` will be set to the midpoint of their operational range when starting up. This ensures the UI reflects a known value.
- Fix bug in HandheldController where a macro that had an up and down event in the same frame would cancel each other out.