### PR TITLE
fix(Renderer): update to using OpenGL renderer by default for compatibility

### DIFF
--- a/core/ui/card_ui/ootbe/plugin_setup.gd
+++ b/core/ui/card_ui/ootbe/plugin_setup.gd
@@ -28,7 +28,7 @@ func _on_state_entered(_from: State) -> void:
 	# If no plugin settings are available, skip to the next state
 	if menus.size() == 0:
 		logger.info("No plugin settings, skipping.")
-		state_machine.replace_state(next_state)
+		state_machine.replace_state.call_deferred(next_state)
 		return
 	
 	# Add the plugin settings menus

--- a/core/ui/card_ui/power/power_menu.gd
+++ b/core/ui/card_ui/power/power_menu.gd
@@ -33,6 +33,20 @@ func _ready() -> void:
 func _on_state_entered(_from: State) -> void:
 	if focus_group:
 		focus_group.grab_focus()
+	
+	# TODO: Fix this
+	# HACK to prevent giant pink texture from flashing for a second on first run
+	# in OpenGL renderer
+	if blur.has_meta("first_run"):
+		return
+	blur.set_meta("first_run", true)
+
+	# Move the blur rect out of view for a few frames
+	blur.position = Vector2(get_tree().get_root().size)
+	
+	# Create a timer and wait for a bit before moving the rect back
+	await get_tree().create_timer(0.2).timeout
+	blur.position = Vector2.ZERO
 
 
 func _on_systemctl_cmd(command: String) -> void:

--- a/core/ui/card_ui/power/power_menu.tscn
+++ b/core/ui/card_ui/power/power_menu.tscn
@@ -85,9 +85,8 @@ theme_override_constants/margin_bottom = 20
 layout_mode = 2
 alignment = 1
 
-[node name="FocusGroup" parent="PanelContainer/MarginContainer/VBoxContainer" node_paths=PackedStringArray("current_focus") instance=ExtResource("9_vlbso")]
+[node name="FocusGroup" parent="PanelContainer/MarginContainer/VBoxContainer" instance=ExtResource("9_vlbso")]
 unique_name_in_owner = true
-current_focus = NodePath("")
 focus_stack = SubResource("Resource_fafkw")
 
 [node name="SectionLabel" parent="PanelContainer/MarginContainer/VBoxContainer" instance=ExtResource("10_y3iyf")]

--- a/project.godot
+++ b/project.godot
@@ -177,3 +177,7 @@ ogui_scroll_right={
 [input_devices]
 
 pointing/emulate_touch_from_mouse=true
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
This is related to #211 where the Vulkan renderer on Godot v4.1 causes hanging issues on some hardware. This change updates the default renderer to use OpenGL until a future engine version fixes the issues we've seen with the Vulkan renderer.