### PR TITLE
Fix first boot menu when no plugins are selected

### DIFF
--- a/core/ui/card_ui/ootbe/plugin_setup.gd
+++ b/core/ui/card_ui/ootbe/plugin_setup.gd
@@ -28,7 +28,7 @@ func _on_state_entered(_from: State) -> void:
 	# If no plugin settings are available, skip to the next state
 	if menus.size() == 0:
 		logger.info("No plugin settings, skipping.")
-		state_machine.replace_state(next_state)
+		state_machine.replace_state.call_deferred(next_state)
 		return
 	
 	# Add the plugin settings menus

--- a/project.godot
+++ b/project.godot
@@ -177,3 +177,7 @@ ogui_scroll_right={
 [input_devices]
 
 pointing/emulate_touch_from_mouse=true
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
This fixes the issue where the first boot menu is blank if no plugins are selected.