### PR TITLE
Add home menu banner showing games from library when library deck is focused

### DIFF
--- a/core/global/library_manager.gd
+++ b/core/global/library_manager.gd
@@ -138,12 +138,14 @@ func add_library_launch_item(library_id: String, item: LibraryLaunchItem) -> voi
 
 	# Update the provider fields on the library item
 	item._provider_id = library_id
-	library_item.launch_items.push_back(item)
+	if not library_item.has_launch_item(library_id):
+		library_item.launch_items.push_back(item)
 	
 	# Send signals to inform about library item
 	if is_new:
 		library_item_added.emit(library_item)
 		library_item.added_to_library.emit()
+		logger.debug("New library item added: " + library_item.name)
 	library_launch_item_added.emit(item)
 	item.added_to_library.emit()
 

--- a/core/ui/card_ui/home/cardui_home.tscn
+++ b/core/ui/card_ui/home/cardui_home.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://o70x5igrlq30"]
+[gd_scene load_steps=20 format=3 uid="uid://o70x5igrlq30"]
 
 [ext_resource type="Script" path="res://core/ui/card_ui/home/cardui_home.gd" id="1_a4a3j"]
 [ext_resource type="PackedScene" uid="uid://orey8uxm7v6v" path="res://core/systems/state/visibility_manager.tscn" id="2_u18ot"]
@@ -10,6 +10,7 @@
 [ext_resource type="Resource" uid="uid://bfoequ6xb7csn" path="res://assets/state/states/qam_button_submenu.tres" id="8_dx6pe"]
 [ext_resource type="Resource" uid="uid://bw0mtk7sso8m2" path="res://assets/state/states/power_menu.tres" id="9_kvuqp"]
 [ext_resource type="Texture2D" uid="uid://d1mksukdkqorr" path="res://assets/images/placeholder-grid-banner.png" id="10_mmfgs"]
+[ext_resource type="PackedScene" uid="uid://rosd00fxjrs8" path="res://core/ui/components/library_banner.tscn" id="11_16gcd"]
 [ext_resource type="PackedScene" uid="uid://b0cyl6fdqxevn" path="res://core/systems/input/scroller_joystick.tscn" id="12_h5dxg"]
 [ext_resource type="PackedScene" uid="uid://bkhrcemal7uxo" path="res://core/ui/components/card.tscn" id="12_m30ge"]
 [ext_resource type="PackedScene" uid="uid://crsu0vpicq0vh" path="res://core/ui/components/library_deck.tscn" id="13_rxwf5"]
@@ -69,6 +70,11 @@ size_flags_stretch_ratio = 1.1
 texture = ExtResource("10_mmfgs")
 expand_mode = 1
 stretch_mode = 6
+
+[node name="LibraryBanner" parent="VBoxContainer/BannerTexture" instance=ExtResource("11_16gcd")]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1
 
 [node name="PanelContainer" type="PanelContainer" parent="VBoxContainer"]
 layout_mode = 2

--- a/core/ui/components/library_banner.gd
+++ b/core/ui/components/library_banner.gd
@@ -1,0 +1,37 @@
+extends Control
+
+var library := load("res://core/global/library_manager.tres") as LibraryManager
+var boxart := load("res://core/global/boxart_manager.tres") as BoxArtManager
+
+var logger := Log.get_logger("LibraryBanner")
+
+@onready var container := $%HFlowContainer
+@onready var timer := $%Timer
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	ready.connect(queue_refresh)
+	var on_item_added := func(_item: LibraryItem):
+		if not timer.is_stopped():
+			return
+		queue_refresh()
+		timer.start()
+	library.library_item_added.connect(on_item_added)
+
+
+func queue_refresh():
+	logger.debug("Queuing banner refresh")
+	refresh.call_deferred()
+
+
+func refresh() -> void:
+	var library_items := library.get_library_items()
+	if library_items.size() == 0:
+		return
+	randomize()
+	
+	for child in container.get_children():
+		var item := library_items[randi() % library_items.size()]
+		var texture := await boxart.get_boxart_or_placeholder(item, BoxArtProvider.LAYOUT.GRID_LANDSCAPE)
+		var texture_rect := child as TextureRect
+		texture_rect.texture = texture

--- a/core/ui/components/library_banner.tscn
+++ b/core/ui/components/library_banner.tscn
@@ -1,0 +1,149 @@
+[gd_scene load_steps=5 format=3 uid="uid://rosd00fxjrs8"]
+
+[ext_resource type="Texture2D" uid="uid://d1mksukdkqorr" path="res://assets/images/placeholder-grid-banner.png" id="1_5oyqx"]
+[ext_resource type="Script" path="res://core/ui/components/library_banner.gd" id="1_yhxxp"]
+
+[sub_resource type="Gradient" id="Gradient_yij5a"]
+colors = PackedColorArray(0, 0, 0, 1, 0, 0, 0, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_vkfnk"]
+gradient = SubResource("Gradient_yij5a")
+width = 1920
+height = 620
+
+[node name="LibraryBanner" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_yhxxp")
+
+[node name="TextureRect" type="TextureRect" parent="."]
+clip_children = 2
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = SubResource("GradientTexture2D_vkfnk")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="Spacer" type="Control" parent="TextureRect"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+rotation = 0.10472
+pivot_offset = Vector2(400, 600)
+
+[node name="MarginContainer" type="MarginContainer" parent="TextureRect/Spacer"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/margin_left = -200
+theme_override_constants/margin_top = -100
+theme_override_constants/margin_right = -200
+theme_override_constants/margin_bottom = -100
+
+[node name="HFlowContainer" type="HFlowContainer" parent="TextureRect/Spacer/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+alignment = 1
+
+[node name="TextureRect1" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect2" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect3" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect4" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect5" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect6" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect7" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect8" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect9" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect10" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect11" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="TextureRect12" type="TextureRect" parent="TextureRect/Spacer/MarginContainer/HFlowContainer"]
+custom_minimum_size = Vector2(460, 215)
+layout_mode = 2
+texture = ExtResource("1_5oyqx")
+expand_mode = 1
+stretch_mode = 6
+
+[node name="Timer" type="Timer" parent="."]
+unique_name_in_owner = true
+wait_time = 5.0
+one_shot = true

--- a/core/ui/components/library_deck.gd
+++ b/core/ui/components/library_deck.gd
@@ -12,6 +12,7 @@ signal unhighlighted
 @onready var card_1 := $%GameCard1 as GameCard
 @onready var card_2 := $%GameCard2 as GameCard
 @onready var card_3 := $%GameCard3 as GameCard
+@onready var timer := $%Timer as Timer
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:

--- a/core/ui/components/library_deck.tscn
+++ b/core/ui/components/library_deck.tscn
@@ -53,3 +53,8 @@ theme_override_constants/margin_left = 80
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
+
+[node name="Timer" type="Timer" parent="."]
+unique_name_in_owner = true
+wait_time = 5.0
+one_shot = true


### PR DESCRIPTION
This change adds a library banner when the library deck is focused on the home menu:

![image](https://github.com/ShadowBlip/OpenGamepadUI/assets/376460/b443a631-3c12-4315-b4de-5eef5e41da38)
