### PR TITLE
fix(PerformanceManager): Fix bugs with PerformanceManager.

### DIFF
--- a/core/systems/threading/utility_thread.tres
+++ b/core/systems/threading/utility_thread.tres
@@ -4,5 +4,5 @@
 
 [resource]
 script = ExtResource("1_svd22")
-name = "AudioThread"
-target_tick_rate = 60
+name = "UtilityThread"
+target_tick_rate = 10

--- a/core/ui/common/qam/powertools_menu.tscn
+++ b/core/ui/common/qam/powertools_menu.tscn
@@ -24,7 +24,14 @@ script = ExtResource("1_qncpn")
 current_focus = NodePath("../CPUBoostButton")
 focus_stack = ExtResource("3_0iyf7")
 
+[node name="WaitLabel" parent="." instance=ExtResource("4_1pfjc")]
+layout_mode = 2
+text = "Reading system info.
+Please wait..."
+horizontal_alignment = 1
+
 [node name="CPUSectionLabel" parent="." instance=ExtResource("4_1pfjc")]
+visible = false
 layout_mode = 2
 text = "CPU Settings"
 
@@ -69,6 +76,7 @@ max_value = 1.0
 min_value = 1.0
 
 [node name="GPUSectionLabel" parent="." instance=ExtResource("4_1pfjc")]
+visible = false
 layout_mode = 2
 text = "GPU Settings"
 


### PR DESCRIPTION
- Fix issue where thread_pool would call certain functions out of roder, causing the UI to desync from the actual hardware status.
- Fix issue when ryzenadj cannot read the mapped memory table causing the system to be set to an extremely low power state.
- Fix issue where PowerTools menu would become visible before the profile was applied and a changed setting woudl apply bad values to the profile for everything not yet loaded.