### PR TITLE
fix(PerformanceManager): Optimize PerformanceManager

### DIFF
--- a/core/systems/performance/performance_manager.gd
+++ b/core/systems/performance/performance_manager.gd
@@ -4,7 +4,8 @@ class_name PerformanceManager
 signal cpu_boost_toggled(state: bool)
 signal cpu_cores_available_updated(available: int)
 signal cpu_cores_used(count: int)
-signal gpu_clk_limits_updated(min: float, max: float, current_min: float, current_max: float)
+signal gpu_clk_current_updated(current_min: float, current_max: float)
+signal gpu_clk_limits_updated(min: float, max: float)
 signal gpu_manual_enabled_updated(state: bool)
 signal gpu_power_profile_updated(index: int)
 signal gpu_temp_limit_updated(current: float)
@@ -12,6 +13,7 @@ signal smt_toggled(state: bool)
 signal tdp_updated(tdp_current: float, boost_current: float)
 signal thermal_profile_updated(index: int)
 signal perfomance_profile_applied(profile: PerformanceProfile)
+signal pm_ready
 
 const USER_PROFILES := "user://data/performance/profiles"
 const POWERTOOLS_PATH := "/usr/share/opengamepadui/scripts/powertools"
@@ -29,30 +31,22 @@ var library_item: LibraryLaunchItem
 var platform_provider: PlatformProvider
 var profile: PerformanceProfile
 var profile_state: String # docked or undocked
-
-var cpu_boost_enabled: bool = false
-var cpu_core_count: int = 1
-var cpu_core_count_current: int = 1
-var cpu_cores_available: int = 1
-var cpu_smt_enabled: bool = false
-var gpu_freq_max: float
-var gpu_freq_max_current: float
-var gpu_freq_min: float
-var gpu_freq_min_current: float
-var gpu_manual_enabled: bool = false
-var gpu_power_profile: int
-var gpu_temp_current: float
-var tdp_boost_current: float
-var tdp_current: float
-var thermal_profile: int
-
+var initialized: bool = false
 var logger := Log.get_logger("PerformanceManager", Log.LEVEL.INFO)
 
 
 func _init():
 	_shared_thread.start()
+	profile = PerformanceProfile.new()
+	if not _platform.loaded:
+		_platform.platform_loaded.connect(_setup, CONNECT_ONE_SHOT)
+		return
+	_setup()
+
+
+func _setup():
+	logger.debug("Setup!")
 	platform_provider = _platform.platform
-	await read_system_components()
 
 	batteries = _power_manager.get_devices_by_type(PowerManager.DEVICE_TYPE.BATTERY)
 	if batteries.size() > 1:
@@ -62,6 +56,7 @@ func _init():
 		_update_profile_state(battery)
 		battery.updated.connect(_on_update_battery.bind(battery))
 
+	_shared_thread.exec(read_system_components)
 
 func _on_update_battery(item: PowerManager.Device):
 	_update_profile_state(item)
@@ -69,9 +64,9 @@ func _on_update_battery(item: PowerManager.Device):
 
 
 func _update_profile_state(item: PowerManager.Device) -> void:
-	var to_state: String = "undocked"
-	if item.state in [PowerManager.DEVICE_STATE.CHARGING, PowerManager.DEVICE_STATE.FULLY_CHARGED, PowerManager.DEVICE_STATE.PENDING_CHARGE]:
-		to_state = "docked"
+	var to_state: String = "docked"
+	if item.state not in [PowerManager.DEVICE_STATE.CHARGING, PowerManager.DEVICE_STATE.FULLY_CHARGED, PowerManager.DEVICE_STATE.PENDING_CHARGE]:
+		to_state = "undocked"
 
 	if profile_state != to_state:
 		logger.debug("Setting system to " + to_state)
@@ -91,9 +86,11 @@ func read_system_components(power_profile: int = 1) -> void:
 		await _read_tdp()
 
 	if gpu.clk_capable:
-		await _read_gpu_perf_level()
-		await _read_gpu_clk_limits()
 		await _enable_performance_write()
+		await _read_gpu_perf_level()
+		if profile.gpu_manual_enabled:
+			await _read_gpu_clk_limits()
+			await _read_gpu_clk_current()
 
 	if cpu.smt_capable:
 		await _read_smt_enabled()
@@ -109,19 +106,26 @@ func read_system_components(power_profile: int = 1) -> void:
 	# There's currently no known way to detect the set profile. Default to
 	# setting power_saving at startup for now. #TODO: Fix this?
 	if gpu.power_profile_capable:
-		gpu_power_profile = power_profile
+		profile.gpu_power_profile = power_profile
 		await _gpu_power_profile_change()
 	logger.debug("Update system components completed")
-
+	logger.debug(profile)
+	initialized = true
+	pm_ready.emit()
 
 ### Manage PerformanceProfile funcs
+
+func _get_profile_name() -> String:
+	var prefix: String = _platform.get_product_name().replace(" ", "_") + "_" + profile_state
+	var postfix: String = "_default_profile.tres"
+	if library_item:
+		postfix = "_" + library_item.name.sha256_text() + ".tres"
+		profile.name = library_item.name
+	return prefix+postfix
 
 ## Saves a PerformanceProfile to the given path.
 func save_profile() -> void:
 	var notify := Notification.new("")
-	if not profile:
-		profile = PerformanceProfile.new()
-	_update_profile(false)
 
 	# Try to save the profile
 	if DirAccess.make_dir_recursive_absolute(USER_PROFILES) != OK:
@@ -147,6 +151,9 @@ func save_profile() -> void:
 
 ## Loads a PerformanceProfile from the given path.
 func load_profile(profile_path: String = "") -> void:
+	if not initialized:
+		logger.warn("Attempt to load profile before PerformanceManager was fully initialized.")
+		return
 	var notify := Notification.new("")
 	var loaded: PerformanceProfile
 	# If no path was specified, try to identify it.
@@ -156,15 +163,13 @@ func load_profile(profile_path: String = "") -> void:
 	# Check if given profile exists
 	logger.debug("Load Profile: " + profile_path)
 	if not FileAccess.file_exists(profile_path):
-		loaded = PerformanceProfile.new()
-		profile = loaded
 		if library_item: 
 			profile.name = library_item.name
-		notify.text = "Created new performance profile for " + profile.name
+		notify.text = "Created new performance profile for " + profile_state + " " + profile.name 
 		logger.debug(notify.text)
 		_notification_manager.show(notify)
 		save_profile()
-		perfomance_profile_applied.emit(profile)
+		_shared_thread.exec(_apply_profile)
 		return
 
 	else:
@@ -180,87 +185,59 @@ func load_profile(profile_path: String = "") -> void:
 		return
 
 	profile = loaded
-	notify.text = "Loaded performance profile: " + profile.name
+	notify.text = "Loaded performance profile: " + profile_state + " " + profile.name 
 	logger.info(notify.text)
+	logger.debug(profile)
 	_notification_manager.show(notify)
-	await _apply_profile()
+	_shared_thread.exec(_apply_profile)
 
 
-func _get_profile_name() -> String:
-	var prefix: String = _platform.get_product_name().replace(" ", "_") + "_" + profile_state
-	var postfix: String = "_default_profile.tres"
-	if library_item:
-		postfix = "_" + library_item.name.sha256_text() + ".tres"
-		profile.name = library_item.name
-	return prefix+postfix
-
-
-func _update_profile(do_save: bool = true) -> void:
-	if not profile:
-		logger.debug("Profile not set, cannot update.")
-		return
-	if cpu.boost_capable:
-		profile.cpu_boost_enabled = cpu_boost_enabled
-	if cpu.smt_capable:
-		profile.cpu_core_count_current = cpu_core_count_current
-		profile.cpu_smt_enabled = cpu_smt_enabled
-	if gpu.clk_capable:
-		profile.gpu_freq_max_current = gpu_freq_max_current
-		profile.gpu_freq_min_current = gpu_freq_min_current
-		profile.gpu_manual_enabled = gpu_manual_enabled
-	if gpu.power_profile_capable:
-		profile.gpu_power_profile = gpu_power_profile
-	if gpu.tj_temp_capable:
-		profile.gpu_temp_current = gpu_temp_current
-	if gpu.tdp_capable:
-		profile.tdp_boost_current = tdp_boost_current
-		profile.tdp_current = tdp_current
-	if gpu.thermal_profile_capable:
-		profile.thermal_profile = thermal_profile
-	if do_save:
-		save_profile()
+func emit_profile_signals() -> void:
+	cpu_boost_toggled.emit(profile.cpu_boost_enabled)
+	cpu_cores_available_updated.emit(cpu.cores_available)
+	cpu_cores_used.emit(profile.cpu_core_count_current)
+	gpu_clk_limits_updated.emit(gpu.freq_min, gpu.freq_max)
+	gpu_clk_current_updated.emit(profile.gpu_freq_min_current, profile.gpu_freq_max_current)
+	gpu_manual_enabled_updated.emit(profile.gpu_manual_enabled)
+	gpu_power_profile_updated.emit(profile.gpu_power_profile)
+	gpu_temp_limit_updated.emit(profile.gpu_temp_current)
+	smt_toggled.emit(profile.cpu_smt_enabled)
+	tdp_updated.emit(profile.tdp_current, profile.tdp_boost_current)
+	thermal_profile_updated.emit(profile.thermal_profile)
 
 
 func _apply_profile() -> void:
 	if cpu.boost_capable:
 		logger.debug("Set CPU Boost from profile: " + str(profile.cpu_boost_enabled))
-		cpu_boost_enabled= profile.cpu_boost_enabled
 		await _apply_cpu_boost_state()
 	if cpu.smt_capable:
 		logger.debug("Set SMT state from profile: " + str(profile.cpu_smt_enabled))
-		cpu_smt_enabled = profile.cpu_smt_enabled
 		await _apply_cpu_smt_state()
 		logger.debug("Set core count from profile: " + str(profile.cpu_core_count_current))
-		cpu_core_count_current = profile.cpu_core_count_current
 		await _change_cpu_cores()
 	if gpu.clk_capable:
 		logger.debug("Set gpu mode from profile: " + str(profile.gpu_manual_enabled))
-		gpu_manual_enabled = profile.gpu_manual_enabled
 		await _gpu_manual_change()
-		if gpu_manual_enabled:
+		if profile.gpu_manual_enabled:
+			if not gpu.freq_min or gpu.freq_max:
+				await _read_gpu_clk_limits()
 			logger.debug("Set gpu frequency range from profile: " + str(profile.gpu_freq_min_current) + "-" + str(profile.gpu_freq_max_current))
-			gpu_freq_max = profile.gpu_freq_max_current
-			gpu_freq_min = profile.gpu_freq_min_current
 			await _gpu_freq_change()
 	if gpu.power_profile_capable:
 		logger.debug("Set gpu power profile from profile: " +str(profile.gpu_power_profile))
-		gpu_power_profile = profile.gpu_power_profile
 		await _gpu_power_profile_change()
 	if gpu.tj_temp_capable:
 		logger.debug("Set gpu temp target from profile: " +str(profile.gpu_temp_current))
-		gpu_temp_current = profile.gpu_temp_current
 		await _gpu_temp_limit_change()
 	if gpu.tdp_capable:
 		logger.debug("Set tdp from profile: " + str(profile.tdp_current) + " boost:" + str(profile.tdp_boost_current))
-		tdp_boost_current = profile.tdp_boost_current
-		tdp_current = profile.tdp_current
 		await _tdp_value_change()
 	if gpu.thermal_profile_capable:
 		logger.debug("Set thermal mode from profile: " +str(profile.thermal_profile))
-		thermal_profile = profile.thermal_profile
 		await _apply_thermal_profile()
-	logger.info("Applied Performance Profile: " + profile.name)
+	logger.info("Applied Performance Profile: " + profile_state + " " + profile.name)
 	perfomance_profile_applied.emit(profile)
+
 
 func on_app_switched(_from: RunningApp, to: RunningApp) -> void:
 	logger.debug("Detected app switch")
@@ -274,136 +251,140 @@ func on_app_switched(_from: RunningApp, to: RunningApp) -> void:
 
 ## Called to set the number of enabled CPU's
 func set_cpu_core_count(value: int) -> void:
-	if cpu_core_count_current == value:
+	if profile.cpu_core_count_current == value:
 		return
-	cpu_core_count_current = value
+	profile.cpu_core_count_current = value
 	await _change_cpu_cores()
-	_update_profile()
+	save_profile()
 
 
 ## Called to toggle cpu boost
 func set_cpu_boost_enabled(state: bool) -> void:
-	if cpu_boost_enabled == state:
+	if profile.cpu_boost_enabled == state:
 		return
-	cpu_boost_enabled = state
+	profile.cpu_boost_enabled = state
 	await _apply_cpu_boost_state()
-	_update_profile()
+	save_profile()
 
 
 ## Called to enable/disable CPU SMT.
 func set_cpu_smt_enabled(state: bool) -> void:
-	if cpu_smt_enabled == state:
+	if profile.cpu_smt_enabled == state:
 		return
-	cpu_smt_enabled = state
+	profile.cpu_smt_enabled = state
 	await _apply_cpu_smt_state()
-	_update_profile()
+	save_profile()
+
 
 ## Called when gpu_freq_max_slider.value is changed.
 func set_gpu_freq_max(value: float) -> void:
-	if gpu_freq_max_current == value:
+	if profile.gpu_freq_max_current == value:
 		return
-	gpu_freq_max_current = value
-	if value < gpu_freq_min_current:
-		gpu_freq_min_current = value
+	profile.gpu_freq_max_current = value
+	if value < profile.gpu_freq_min_current:
+		profile.gpu_freq_min_current = value
 	await _gpu_freq_change()
-	_update_profile()
+	save_profile()
 
 
 ## Called to set the minimum gpu clock is changed.
 func set_gpu_freq_min(value: float) -> void:
-	if gpu_freq_min_current == value:
+	if profile.gpu_freq_min_current == value:
 		return
-	gpu_freq_min_current = value
-	if value > gpu_freq_max_current:
-		gpu_freq_max_current = value
+	profile.gpu_freq_min_current = value
+	if value > profile.gpu_freq_max_current:
+		profile.gpu_freq_max_current = value
 	await _gpu_freq_change()
-	_update_profile()
+	save_profile()
 
 
 ## Called to toggle auto/manual gpu clocking
 func set_gpu_manual_enabled(state: bool) -> void:
-	if gpu_manual_enabled == state:
+	if profile.gpu_manual_enabled == state:
 		return
-	gpu_manual_enabled = state
+	profile.gpu_manual_enabled = state
 	await _gpu_manual_change()
 
-	if gpu_manual_enabled:
-		await _read_gpu_clk_limits()
-	_update_profile()
+	if profile.gpu_manual_enabled:
+		if not gpu.freq_max or not gpu.freq_min:
+			await _read_gpu_clk_limits()
+		await _read_gpu_clk_current()
+	save_profile()
 
 
 ## Called to set the GPU Power Profile
 func set_gpu_power_profile(mode: int) -> void:
-	if gpu_power_profile == mode:
+	if profile.gpu_power_profile == mode:
 		return
-	gpu_power_profile = mode
+	profile.gpu_power_profile = mode
 	await _gpu_power_profile_change()
-	_update_profile()
+	save_profile()
 
 
 ## Called to set the GPU Thermal Throttle Limit
 func set_gpu_temp_current(value: float) -> void:
-	if gpu_temp_current == value:
+	if profile.gpu_temp_current == value:
 		return
-	gpu_temp_current = value
+	profile.gpu_temp_current = value
 	await _gpu_temp_limit_change()
-	_update_profile()
+	save_profile()
 
 
 ## Called to set the TFP boost limit.
 func set_tdp_boost_value(value: float) -> void:
-	if tdp_boost_current == value:
+	if profile.tdp_boost_current == value:
 		return
-	tdp_boost_current = value
+	profile.tdp_boost_current = value
 	await _tdp_boost_value_change()
-	_update_profile()
+	save_profile()
 
 
 ## Called to set the TDP average limit.
 func set_tdp_value(value: float) -> void:
-	if tdp_current == value:
+	if profile.tdp_current == value:
 		return
-	tdp_current = value
+	profile.tdp_current = value
 	await _tdp_value_change()
-	_update_profile()
+	save_profile()
 
 
 ## Sets the thermal throttle mode for ASUS devices.
 func set_thermal_profile(index: int) -> void:
-	if thermal_profile == index:
+	if profile.thermal_profile == index:
 		return
-	thermal_profile = index
+	profile.thermal_profile = index
 	await _apply_thermal_profile()
-	_update_profile()
+	save_profile()
+
 
 ### Adjust sysfs funcs
 func _apply_cpu_boost_state() -> void:
 	var args := ["cpuBoost", "0"]
-	if cpu_boost_enabled:
+	if profile.cpu_boost_enabled:
 		args = ["cpuBoost", "1"]
 	await _async_do_exec(POWERTOOLS_PATH, args)
-	cpu_boost_toggled.emit(cpu_boost_enabled)
+	cpu_boost_toggled.emit(profile.cpu_boost_enabled)
 
 
 func _apply_thermal_profile() -> void:
 	if not platform_provider is HandheldPlatform:
 		logger.warn("Attempt to apply thermoal profile on platform that is not HandheldPlatform.")
 		return
-	match thermal_profile:
+	match profile.thermal_profile:
 			"0":
 				logger.debug("Setting thermal throttle policy to Balanced")
 			"1":
 				logger.debug("Setting thermal throttle policy to Performance")
 			"2":
 				logger.debug("Setting thermal throttle policy to Silent")
-	var args := ["setThermalPolicy", str(thermal_profile)]
+	var args := ["setThermalPolicy", str(profile.thermal_profile)]
 	await _async_do_exec((platform_provider as HandheldPlatform).thermal_policy_path, args)
-	thermal_profile_updated.emit(thermal_profile)
+	thermal_profile_updated.emit(profile.thermal_profile)
 
 
 func _apply_cpu_smt_state() -> void:
 	var args := []
-	if cpu_smt_enabled:
+	if profile.cpu_smt_enabled:
 		args = ["smtToggle", "on"]
 	else:
 		args = ["smtToggle", "off"]
@@ -412,40 +393,40 @@ func _apply_cpu_smt_state() -> void:
 	if exit_code:
 		logger.warn("_on_toggle_smt exit code: " + str(exit_code))
 		return
-	smt_toggled.emit(cpu_smt_enabled)
+	smt_toggled.emit(profile.cpu_smt_enabled)
 	await _read_cpu_count()
 	await _read_cpus_enabled()
 
 ## Set STAPM on AMD APU's
 func _amd_tdp_change() -> void:
 	logger.debug("Doing callback func _do_amd_tdp_change")
-	await _async_do_exec(POWERTOOLS_PATH, ["ryzenadj", "-a", str(tdp_current * 1000)])
+	await _async_do_exec(POWERTOOLS_PATH, ["ryzenadj", "-a", str(profile.tdp_current * 1000)])
 
 
 ## Set long/short PPT on AMD APU's
 func _amd_tdp_boost_change() -> void:
 	logger.debug("Doing callback func _do_amd_tdp_boost_change")
 	
-	var slowPPT: float = (floor(tdp_boost_current/2) + tdp_current) * 1000
-	var fastPPT: float = (tdp_boost_current + tdp_current) * 1000
+	var slowPPT: float = (floor(profile.tdp_boost_current/2) + profile.tdp_current) * 1000
+	var fastPPT: float = (profile.tdp_boost_current + profile.tdp_current) * 1000
 	await _async_do_exec(POWERTOOLS_PATH, ["ryzenadj", "-b", str(fastPPT)])
 	await _async_do_exec(POWERTOOLS_PATH, ["ryzenadj", "-c", str(slowPPT)])
 
 
 # Called to disable/enable cores by count as specified by value. 
 func _change_cpu_cores():
-	logger.debug("Enable cpu_cores: " +str(cpu_core_count_current) + "/" + str(cpu_core_count))
+	logger.debug("Enable cpu_cores: " +str(profile.cpu_core_count_current) + "/" + str(cpu.core_count))
 	var args := []
-	for cpu_no in range(1, cpu_core_count):
+	for cpu_no in range(1, cpu.core_count):
 		args = ["cpuToggle", str(cpu_no), "1"]
-		if cpu_smt_enabled and cpu_no >= cpu_core_count_current:
+		if profile.cpu_smt_enabled and cpu_no >= profile.cpu_core_count_current:
 			args[2] = "0"
-		elif not cpu_smt_enabled:
-			if cpu_no % 2 != 0 or cpu_no >= (cpu_core_count_current * 2) - 1:
+		elif not profile.cpu_smt_enabled:
+			if cpu_no % 2 != 0 or cpu_no >= (profile.cpu_core_count_current * 2) - 1:
 				args[2] = "0"
 		logger.debug("Set CPU No: " + str(args[1]) + " to " + args[2])
 		await _async_do_exec(POWERTOOLS_PATH, args)
-	cpu_cores_used.emit(cpu_core_count_current)
+	cpu_cores_used.emit(profile.cpu_core_count_current)
 
 
 ## Called to set write permissions to power_dpm_force_performace_level
@@ -459,10 +440,10 @@ func _enable_performance_write() -> void:
 
 ## Ensures the current boost doesn't exceed the max boost.
 func _ensure_tdp_boost_limited()  -> void:
-	if tdp_boost_current > gpu.max_boost:
-		tdp_boost_current = gpu.max_boost
-	if tdp_boost_current < 0:
-		tdp_boost_current = 0
+	if profile.tdp_boost_current > gpu.max_boost:
+		profile.tdp_boost_current = gpu.max_boost
+	if profile.tdp_boost_current < 0:
+		profile.tdp_boost_current = 0
 
 
 ## Set the GPU min/max freq.
@@ -473,35 +454,35 @@ func _gpu_freq_change() -> void:
 			cmd = "amdGpuClock"
 		"Intel":
 			cmd = "intelGpuClock"
-	await _async_do_exec(POWERTOOLS_PATH, [cmd, str(gpu_freq_min_current), str(gpu_freq_max_current)])
-	gpu_clk_limits_updated.emit(gpu_freq_min, gpu_freq_max, gpu_freq_min_current, gpu_freq_max_current)
+	await _async_do_exec(POWERTOOLS_PATH, [cmd, str(profile.gpu_freq_min_current), str(profile.gpu_freq_max_current)])
+	gpu_clk_current_updated.emit(profile.gpu_freq_min_current, profile.gpu_freq_max_current)
 
 
 func _gpu_manual_change() -> void:
 	if gpu.vendor == "AMD":
 		var args := ["pdfpl", "auto"]
-		if gpu_manual_enabled:
+		if profile.gpu_manual_enabled:
 			args = ["pdfpl", "manual"]
 		var output: Array = await _async_do_exec(POWERTOOLS_PATH, args)
 		var exit_code = output[1]
 		if exit_code:
 			logger.warn("_on_toggle_gpu_freq exit code: " + str(exit_code))
 
-		gpu_manual_enabled_updated.emit(gpu_manual_enabled)
+		gpu_manual_enabled_updated.emit(profile.gpu_manual_enabled)
 
 
 # TODO: Support more than AMD APU's
 ## Sets the ryzenadj power profile
 func _gpu_power_profile_change() -> void:
 	var power_profile := "--max-performance"
-	if gpu_power_profile == 1:
+	if profile.gpu_power_profile == 1:
 		power_profile = "--power-saving"
 	match gpu.vendor:
 		"AMD":
 			await _async_do_exec(POWERTOOLS_PATH, ["ryzenadj", power_profile])
 		"Intel":
 			pass
-	gpu_power_profile_updated.emit(gpu_power_profile)
+	gpu_power_profile_updated.emit(profile.gpu_power_profile)
 
 
 # TODO: Support more than AMD APU's
@@ -509,17 +490,17 @@ func _gpu_power_profile_change() -> void:
 func _gpu_temp_limit_change() -> void:
 	match gpu.vendor:
 		"AMD":
-			await _async_do_exec(POWERTOOLS_PATH, ["ryzenadj", "-f", str(gpu_temp_current)])
+			await _async_do_exec(POWERTOOLS_PATH, ["ryzenadj", "-f", str(profile.gpu_temp_current)])
 		"Intel":
 			pass
-	gpu_temp_limit_updated.emit(gpu_temp_current)
+	gpu_temp_limit_updated.emit(profile.gpu_temp_current)
 
 
 # Set short/peak TDP on Intel iGPU's
 func _intel_tdp_boost_change() -> void:
 	logger.debug("Doing callback func _do_intel_tdp_boost_change")
-	var shortTDP: float = (floor(tdp_boost_current/2) + tdp_current) * 1000000
-	var peakTDP: float = (tdp_boost_current + tdp_current) * 1000000
+	var shortTDP: float = (floor(profile.tdp_boost_current/2) + profile.tdp_current) * 1000000
+	var peakTDP: float = (profile.tdp_boost_current + profile.tdp_current) * 1000000
 	var results := await _async_do_exec(POWERTOOLS_PATH, ["set_rapl", "constraint_1_power_limit_uw", str(shortTDP)])
 	for result in results:
 		logger.debug("Result: " +str(result))
@@ -531,7 +512,7 @@ func _intel_tdp_boost_change() -> void:
 # Set long TDP on Intel iGPU's
 func _intel_tdp_change() -> void:
 	logger.debug("Doing callback func _do_intel_tdp_change")
-	var results := await _async_do_exec(POWERTOOLS_PATH, ["setRapl", "constraint_0_power_limit_uw", str(tdp_current * 1000000)])
+	var results := await _async_do_exec(POWERTOOLS_PATH, ["setRapl", "constraint_0_power_limit_uw", str(profile.tdp_current * 1000000)])
 	for result in results:
 		logger.debug("Result: " +str(result))
 
@@ -544,7 +525,7 @@ func _tdp_boost_value_change(emit_change: bool = true) -> void:
 		"Intel":
 			await _intel_tdp_boost_change()
 	if emit_change:
-		tdp_updated.emit(tdp_current, tdp_boost_current)
+		tdp_updated.emit(profile.tdp_current, profile.tdp_boost_current)
 
 
 
@@ -556,27 +537,47 @@ func _tdp_value_change() -> void:
 		"Intel":
 			await _intel_tdp_change()
 	await _tdp_boost_value_change(false)
-	tdp_updated.emit(tdp_current, tdp_boost_current)
+	tdp_updated.emit(profile.tdp_current, profile.tdp_boost_current)
 
 
 # Sets the current TDP to the midpoint of the detected hardware. Used when we're not able to
 # Determine the current settings.
 func _set_sane_defaults() -> void:
-	if not tdp_current:
-		tdp_current = float((gpu.max_tdp - gpu.min_tdp) / 2 + gpu.min_tdp)
-	if not tdp_boost_current:
-		tdp_boost_current = 0
-	if not gpu_temp_current:
-		gpu_temp_current = FALLBACK_GPU_TEMP
+	if not profile.tdp_current:
+		profile.tdp_current = float((gpu.tdp_max - gpu.tdp_min) / 2 + gpu.tdp_min)
+	if not profile.tdp_boost_current:
+		profile.tdp_boost_current = 0
+	if not profile.gpu_temp_current:
+		profile.gpu_temp_current = FALLBACK_GPU_TEMP
 	await _tdp_value_change()
 	await _gpu_temp_limit_change()
 
 
 ### Read from sysfs funcs
 
-## Reads the pp_od_clk_voltage from sysfs and returns the values. This file will 
+## Reads the pp_od_clk_voltage from sysfs and returns the OD_RANGE values. This file will 
 ## be empty if not in "manual" for pp_od_performance_level.
 func _read_amd_gpu_clock_limits() -> void:
+	var args := ["/sys/class/drm/card0/device/pp_od_clk_voltage"]
+	var output: Array = await _async_do_exec("cat", args)
+	@warning_ignore("unsafe_method_access")
+	var result := (output[0][0] as String).split("\n")
+	logger.debug(result)
+	for param in result:
+		var parts := param.split("\n")
+		for part in parts:
+			var fixed_part := part.strip_edges().split(" ", false)
+			if fixed_part.is_empty() or fixed_part in ["0:", "1:"]:
+				continue
+			if fixed_part[0] == "SCLK:":
+				gpu.freq_min = int(fixed_part[1].rstrip("Mhz"))
+				gpu.freq_max = int(fixed_part[2].rstrip("Mhz"))
+	logger.debug("Found GPU CLK Limits: " + str(gpu.freq_min) + " - " + str(gpu.freq_max))
+
+
+## Reads the pp_od_clk_voltage from sysfs and returns the OD_SCLK values. This file will 
+## be empty if not in "manual" for pp_od_performance_level.
+func _read_amd_gpu_clock_current() -> void:
 	var args := ["/sys/class/drm/card0/device/pp_od_clk_voltage"]
 	var output: Array = await _async_do_exec("cat", args)
 	@warning_ignore("unsafe_method_access")
@@ -586,24 +587,21 @@ func _read_amd_gpu_clock_limits() -> void:
 		var parts := param.split("\n")
 		for part in parts:
 			var fixed_part := part.strip_edges().split(" ", false)
-			if fixed_part.is_empty():
+			if fixed_part.is_empty() or fixed_part[0] == "SCLK:" :
 				continue
-			if fixed_part[0] == "SCLK:":
-				gpu_freq_max = int(fixed_part[2].rstrip("Mhz"))
-				gpu_freq_min = int(fixed_part[1].rstrip("Mhz"))
-			elif fixed_part[0] == "0:":
-				gpu_freq_min_current =  int(fixed_part[1].rstrip("Mhz"))
+			if fixed_part[0] == "0:":
+				profile.gpu_freq_min_current =  int(fixed_part[1].rstrip("Mhz"))
 			elif fixed_part[0] == "1:":
-				gpu_freq_max_current =  int(fixed_part[1].rstrip("Mhz"))
-	logger.debug("Found GPU CLK Limits: " + str(gpu_freq_min) + " - " + str(gpu_freq_max))
+				profile.gpu_freq_max_current =  int(fixed_part[1].rstrip("Mhz"))
+	logger.debug("Found GPU CLK Current: " + str(profile.gpu_freq_min_current) + " - " + str(profile.gpu_freq_max_current))
 
 
 func _read_amd_gpu_perf_level() -> void:
 	var performance_level = await  _read_sys("/sys/class/drm/card0/device/power_dpm_force_performance_level")
 	if performance_level == "manual":
-		gpu_manual_enabled = true
+		profile.gpu_manual_enabled = true
 	else:
-		gpu_manual_enabled = false
+		profile.gpu_manual_enabled = false
 
 
 # TODO: Find a way to detect this.
@@ -639,25 +637,25 @@ func _read_amd_tdp() -> void:
 				"PPT LIMIT FAST":
 					current_fastppt = float(value)
 				"STAPM LIMIT":
-					tdp_current = float(value)
+					profile.tdp_current = float(value)
 				"THM LIMIT CORE":
-					gpu_temp_current = float(value)
+					profile.gpu_temp_current = float(value)
 		else:
 			match parts[1]:
 				"PPT LIMIT FAST":
 					logger.warn("RyzenAdj unable to read current " + parts[1] + " value. Setting to sane default.")
 					set_sane_defaults = true
-					current_fastppt = float((gpu.max_tdp - gpu.min_tdp) / 2 + gpu.min_tdp)
+					current_fastppt = float((gpu.tdp_max - gpu.tdp_min) / 2 + gpu.tdp_min)
 				"STAPM LIMIT":
 					logger.warn("RyzenAdj unable to read current " + parts[1] + " value. Setting to sane default.")
 					set_sane_defaults = true
-					tdp_current = float((gpu.max_tdp - gpu.min_tdp) / 2 + gpu.min_tdp)
+					profile.tdp_current = float((gpu.tdp_max - gpu.tdp_min) / 2 + gpu.tdp_min)
 				"THM LIMIT CORE":
 					logger.warn("RyzenAdj unable to read current " + parts[1] + " value. Setting to sane default.")
 					set_sane_defaults = true
-					gpu_temp_current = FALLBACK_GPU_TEMP
+					profile.gpu_temp_current = FALLBACK_GPU_TEMP
 
-	tdp_boost_current = current_fastppt - tdp_current
+	profile.tdp_boost_current = current_fastppt - profile.tdp_current
 	_ensure_tdp_boost_limited()
 	if set_sane_defaults:
 		await _set_sane_defaults()
@@ -666,28 +664,28 @@ func _read_amd_tdp() -> void:
 
 
 func _read_cpu_boost_enabled() -> void:
-	if FileAccess.file_exists("/sys/devices/system/cpu/cpufreq/boost"):
-		var boost_set :=  await  _read_sys("/sys/devices/system/cpu/cpufreq/boost")
-		logger.debug("cpu boost is set to: " + boost_set)
-		if boost_set == "1":
-			cpu_boost_enabled = true
-	else:
-		cpu.boost_capable = false
-	cpu_boost_toggled.emit(cpu_boost_enabled)
+	if not  FileAccess.file_exists("/sys/devices/system/cpu/cpufreq/boost"):
+		logger.warn("Attempted to read CPU boost when CPU is not possible.")
+
+	var boost_set :=  await  _read_sys("/sys/devices/system/cpu/cpufreq/boost")
+	profile.cpu_boost_enabled = boost_set == "1"
+
+	logger.debug("CPU boost enabled: " + str(profile.cpu_boost_enabled))
+	cpu_boost_toggled.emit(profile.cpu_boost_enabled)
 
 
 ## Loops through all cores and returns the count of enabled cores.
 func _read_cpus_enabled() -> void:
 	var active_cpus := 1
-	for i in range(1, cpu_core_count):
+	for i in range(1, cpu.core_count):
 		var args = ["-c", "cat /sys/bus/cpu/devices/cpu"+str(i)+"/online"]
 		var output: Array = await _async_do_exec("bash", args)
 		logger.debug("Add to count: " + str((output[0][0] as String).strip_edges()))
 		active_cpus += int((output[0][0] as String).strip_edges())
 		logger.debug("Detected Active CPU's: " + str(active_cpus))
-	cpu_core_count_current = active_cpus
-	logger.debug("Total Active CPU's: " + str(cpu_core_count_current))
-	cpu_cores_used.emit(cpu_core_count_current)
+	profile.cpu_core_count_current = active_cpus
+	logger.debug("Total Active CPU's: " + str(profile.cpu_core_count_current))
+	cpu_cores_used.emit(profile.cpu_core_count_current)
 
 
 ## Updates the total number of cores
@@ -698,13 +696,13 @@ func _read_cpu_count() -> void:
 	if exit_code:
 		logger.warn("Unable to update CPU count. Received exit code: " +str(exit_code))
 		return
-	cpu_core_count = (output[0][0] as String).split("\n")[0] as int
-	cpu_cores_available = cpu_core_count
-	if not cpu_smt_enabled:
+	cpu.core_count = (output[0][0] as String).split("\n")[0] as int
+	cpu.cores_available = cpu.core_count
+	if not profile.cpu_smt_enabled:
 		@warning_ignore("integer_division")
-		cpu_cores_available = cpu_core_count / 2
-	logger.debug("Total CPU's: " + str(cpu_core_count) + " Available CPU's: " + str(cpu_cores_available))
-	cpu_cores_available_updated.emit(cpu_cores_available)
+		cpu.cores_available = cpu.core_count / 2
+	logger.debug("Total CPU's: " + str(cpu.core_count) + " Available CPU's: " + str(cpu.cores_available))
+	cpu_cores_available_updated.emit(cpu.cores_available)
 
 
 ## Reads the current and absolute min/max gpu clocks.
@@ -714,7 +712,16 @@ func _read_gpu_clk_limits() -> void:
 			await _read_amd_gpu_clock_limits()
 		"Intel":
 			await _read_intel_gpu_clock_limits()
-	gpu_clk_limits_updated.emit(gpu_freq_min, gpu_freq_max, gpu_freq_min_current, gpu_freq_max_current)
+	gpu_clk_limits_updated.emit(gpu.freq_min, gpu.freq_max)
+
+
+func _read_gpu_clk_current() -> void:
+	match gpu.vendor:
+		"AMD":
+			await _read_amd_gpu_clock_current()
+		"Intel":
+			await _read_intel_gpu_clock_current()
+	gpu_clk_current_updated.emit(profile.gpu_freq_min_current, profile.gpu_freq_max_current)
 
 
 ## Called to read the current performance level and set the UI as needed.
@@ -724,7 +731,7 @@ func _read_gpu_perf_level() -> void:
 			await _read_amd_gpu_perf_level()
 		_:
 			return
-	gpu_manual_enabled_updated.emit(gpu_manual_enabled)
+	gpu_manual_enabled_updated.emit(profile.gpu_manual_enabled)
 
 
 func _read_gpu_power_profile() -> void:
@@ -733,16 +740,21 @@ func _read_gpu_power_profile() -> void:
 			_read_amd_gpu_power_profile()
 		_:
 			return
-	gpu_power_profile_updated.emit(gpu_power_profile)
+	gpu_power_profile_updated.emit(profile.gpu_power_profile)
 
 
 ## Reads the following sysfs paths to update the current and mix/max gpu frequencies.
 func _read_intel_gpu_clock_limits() -> void:
-	gpu_freq_max = float(await _read_sys("/sys/class/drm/card0/gt_RP0_freq_mhz"))
-	gpu_freq_max_current = float(await _read_sys("/sys/class/drm/card0/gt_max_freq_mhz"))
-	gpu_freq_min = float(await _read_sys("/sys/class/drm/card0/gt_RPn_freq_mhz"))
-	gpu_freq_min_current = float(await _read_sys("/sys/class/drm/card0/gt_min_freq_mhz"))
-	logger.debug("Found GPU CLK Limits: " + str(gpu_freq_min) + " - " + str(gpu_freq_max))
+	gpu.freq_max = float(await _read_sys("/sys/class/drm/card0/gt_RP0_freq_mhz"))
+	gpu.freq_min = float(await _read_sys("/sys/class/drm/card0/gt_RPn_freq_mhz"))
+	
+	logger.debug("Found GPU CLK Limits: " + str(gpu.freq_min) + " - " + str(gpu.freq_max))
+
+
+func _read_intel_gpu_clock_current() -> void:
+	profile.gpu_freq_max_current = float(await _read_sys("/sys/class/drm/card0/gt_max_freq_mhz"))
+	profile.gpu_freq_min_current = float(await _read_sys("/sys/class/drm/card0/gt_min_freq_mhz"))
+	logger.debug("Found GPU CLK Current: " + str(profile.gpu_freq_min_current) + " - " + str(profile.gpu_freq_max_current))
 
 
 ## Retrieves the current TDP from sysfs for Intel iGPU's.
@@ -752,12 +764,12 @@ func _read_intel_tdp() -> void:
 		logger.warn("Unable to determine long TDP.")
 		return
 
-	tdp_current = long_tdp / 1000000
+	profile.tdp_current = long_tdp / 1000000
 	var peak_tdp: float = float(await _read_sys("/sys/class/powercap/intel-rapl/intel-rapl:0/constraint_2_power_limit_uw"))
 	if not peak_tdp:
 		logger.warn("Unable to determine long TDP.")
 		return
-	tdp_boost_current = peak_tdp / 1000000 - tdp_current
+	profile.tdp_boost_current = peak_tdp / 1000000 - profile.tdp_current
 	_ensure_tdp_boost_limited()
 	await _tdp_boost_value_change()
 
@@ -767,10 +779,10 @@ func _read_smt_enabled() -> void:
 		var smt_set := await  _read_sys("/sys/devices/system/cpu/smt/control")
 		logger.debug("SMT is set to" + smt_set)
 		if smt_set == "on":
-			cpu_smt_enabled = true
+			profile.cpu_smt_enabled = true
 	await _read_cpus_enabled()
 	await _read_cpu_count()
-	smt_toggled.emit(cpu_smt_enabled)
+	smt_toggled.emit(profile.cpu_smt_enabled)
 
 
 ## Retrieves the current TDP.
@@ -780,7 +792,7 @@ func _read_tdp() -> void:
 			await _read_amd_tdp()
 		"Intel":
 			await _read_intel_tdp()
-	tdp_updated.emit(tdp_current, tdp_boost_current)
+	tdp_updated.emit(profile.tdp_current, profile.tdp_boost_current)
 
 
 ## Retrieves the current thermal mode.
@@ -792,28 +804,32 @@ func _read_thermal_profile() -> void:
 		logger.warn("Attempted to call thermal profile property on a Platform that is not thermal profile capable.")
 		return
 
-	thermal_profile = int(await _read_sys((platform_provider as HandheldPlatform).thermal_policy_path))
-	match thermal_profile:
+	profile.thermal_profile = int(await _read_sys((platform_provider as HandheldPlatform).thermal_policy_path))
+	match profile.thermal_profile:
 		0:
 			logger.debug("Thermal throttle policy currently at Balanced")
 		1:
 			logger.debug("Thermal throttle policy currently at Performance")
 		2:
 			logger.debug("Thermal throttle policy currently at Silent")
-	thermal_profile_updated.emit(thermal_profile)
+	thermal_profile_updated.emit(profile.thermal_profile)
 
 
 # Used to read values from sysfs
 func _read_sys(path: String) -> String:
-	var output: Array = await _async_do_exec("cat", [path])
-	return (output[0][0] as String).strip_escapes()
+	var result := await _async_do_exec("cat", [path])
+	if result[1] != OK:
+		logger.warn("failed to read path: " + path)
+		return ""
+	return (result[0][0] as String).strip_escapes()
 
 
 # Thread safe method of calling _do_exec
 func _async_do_exec(command: String, args: Array)-> Array:
-	logger.debug("Start async_do_exec : " + command)
-	for arg in args:
-		logger.debug(str(arg))
+	logger.debug("Start async_do_exec : " + command + " " + str(args))
+#	var cmd := Command.new(command, args)
+#	var exit_code := await cmd.execute()
+#	return [cmd.stdout, exit_code]
 	return await _shared_thread.exec(_do_exec.bind(command, args))
 
 

--- a/core/systems/performance/performance_profile.gd
+++ b/core/systems/performance/performance_profile.gd
@@ -15,3 +15,18 @@ class_name PerformanceProfile
 @export var tdp_boost_current: float
 @export var tdp_current: float
 @export var thermal_profile: int
+
+
+func _to_string() -> String:
+	return "<PerformanceProfile: " + name +  ", " \
+		+ "cpu_boost_enabled: " + str(cpu_boost_enabled) +  ", " \
+		+ "cpu_core_count_current: " + str(cpu_core_count_current) +  ", " \
+		+ "cpu_smt_enabled: " + str(cpu_smt_enabled) +  ", " \
+		+ "gpu_freq_max_current: " + str(gpu_freq_max_current) +  ", " \
+		+ "gpu_freq_min_current: " + str(gpu_freq_min_current) +  ", " \
+		+ "gpu_manual_enabled: " + str(gpu_manual_enabled) +  ", " \
+		+ "gpu_power_profile: " + str(gpu_power_profile) +  ", " \
+		+ "gpu_temp_current: " + str(gpu_temp_current) +  ", " \
+		+ "tdp_boost_current: " + str(tdp_boost_current) +  ", " \
+		+ "tdp_current: " + str(tdp_current) +  ", " \
+		+ "thermal_profile: " + str(thermal_profile) + ">"


### PR DESCRIPTION
- Use profile.var instead of var for profile related variables.
- Synchronize initial loading flow using signals.
- Simplify some functions for AMDGPU clock reading.