### PR TITLE
fix(HardwareManager): fix GPU port signals and add test

### DIFF
--- a/core/systems/hardware/drm_card_info.gd
+++ b/core/systems/hardware/drm_card_info.gd
@@ -1,7 +1,9 @@
 extends Resource
 class_name DRMCardInfo
 
-## Data container for /sys/class/drm/cardX information
+## GPU card state
+##
+## Represents the data contained in /sys/class/drm/cardX
 
 const drm_path := "/sys/class/drm"
 
@@ -17,19 +19,19 @@ var subvendor_id: String
 var revision_id: String
 
 
-## Returns a [Port] object for the given port directory (E.g. card1-HDMI-A-1)
-func get_port(port_dir: String) -> Port:
+## Returns a [DRMCardPort] object for the given port directory (E.g. card1-HDMI-A-1)
+func get_port(port_dir: String) -> DRMCardPort:
 	var port_name := port_dir.trim_prefix(name + "-")
 	
 	# Try to load the port info if it already exists
-	var res_path := "/".join(["drmcardinfo://", vendor_id, device_id, subvendor_id, subdevice_id, port_name])
+	var res_path := "/".join(["drmcardinfo:/", vendor_id, device_id, subvendor_id, subdevice_id, port_name])
 	if ResourceLoader.exists(res_path):
-		var port := load(res_path) as Port
+		var port := load(res_path) as DRMCardPort
 		port.update()
 		return port
 
 	# Create a new port instance and take over the caching path
-	var port := Port.new()
+	var port := DRMCardPort.new()
 	port.take_over_path(res_path)
 	port.name = port_name
 	port.path = "/".join([drm_path, port_dir])
@@ -39,8 +41,8 @@ func get_port(port_dir: String) -> Port:
 
 
 ## Returns an array of connectors that are attached to this GPU card
-func get_ports() -> Array[Port]:
-	var found_ports: Array[Port] = []
+func get_ports() -> Array[DRMCardPort]:
+	var found_ports: Array[DRMCardPort] = []
 	for directory in DirAccess.get_directories_at(drm_path):
 		if not directory.begins_with(name):
 			continue
@@ -66,129 +68,3 @@ func _to_string() -> String:
 		+ ") Revision ID: (" + str(revision_id) \
 		+ ") Ports: (" + str(get_ports()) \
 		+ ")>"
-
-
-## Data container for /sys/class/drm/cardX-YYYY information
-class Port extends Resource:
-	## Mutex used for thread safety
-	var mutex := Mutex.new()
-	## Name of the port. E.g. HDMI-A-1
-	var name: String
-	## Full path to the port. E.g. /sys/class/drm/card1-HDMI-A-1
-	var path: String
-	## The connector id. E.g. /sys/class/drm/card1-HDMI-A-1/connector_id
-	var connector_id := -1:
-		get:
-			mutex.lock()
-			var prop := connector_id
-			mutex.unlock()
-			return prop
-		set(v):
-			if connector_id == v:
-				return
-			mutex.lock()
-			connector_id = v
-			mutex.unlock()
-			emit_signal.call_deferred("changed")
-	## Whether or not the port is enabled
-	var enabled := false:
-		get:
-			mutex.lock()
-			var prop := enabled
-			mutex.unlock()
-			return prop
-		set(v):
-			if enabled == v:
-				return
-			mutex.lock()
-			enabled = v
-			mutex.unlock()
-			emit_signal.call_deferred("changed")
-	## An array of valid modes (E.g. ["1024x768", "1920x1080"])
-	var modes := PackedStringArray():
-		get:
-			mutex.lock()
-			var prop := modes
-			mutex.unlock()
-			return prop
-		set(v):
-			if modes == v:
-				return
-			mutex.lock()
-			modes = v
-			mutex.unlock()
-			emit_signal.call_deferred("changed")
-	## Status of the port (e.g. "connected")
-	var status: String:
-		get:
-			mutex.lock()
-			var prop := status
-			mutex.unlock()
-			return prop
-		set(v):
-			if status == v:
-				return
-			mutex.lock()
-			status = v
-			mutex.unlock()
-			emit_signal.call_deferred("changed")
-	## Display power management signaling
-	var dpms: bool:
-		get:
-			mutex.lock()
-			var prop := dpms
-			mutex.unlock()
-			return prop
-		set(v):
-			if dpms == v:
-				return
-			mutex.lock()
-			dpms = v
-			mutex.unlock()
-			emit_signal.call_deferred("changed")
-
-	# Updates the properties of the port
-	func update() -> void:
-		connector_id = get_connector_id()
-		enabled = get_enabled()
-		modes = get_modes()
-		status = get_status()
-		dpms = get_dpms()
-
-	func get_connector_id() -> int:
-		var id_str := _get_property("connector_id").strip_escapes()
-		if id_str.is_valid_int():
-			return id_str.to_int()
-		return -1
-
-	func get_enabled() -> bool:
-		return _get_property("enabled").strip_escapes() == "enabled"
-
-	func get_modes() -> PackedStringArray:
-		var found_modes := PackedStringArray()
-		var modes_str := _get_property("modes")
-		for mode in modes_str.split("\n"):
-			found_modes.append(mode.strip_escapes())
-		return found_modes
-		
-	func get_status() -> String:
-		return _get_property("status").strip_escapes()
-
-	func get_dpms() -> bool:
-		return _get_property("dpms").strip_escapes() == "On"
-
-	func _get_property(prop: String) -> String:
-		var prop_path := "/".join([path, prop])
-		if not FileAccess.file_exists(prop_path):
-			return ""
-		var output := []
-		OS.execute("cat", [prop_path], output)
-		var value := output[0] as String
-		return value
-
-	func _to_string() -> String:
-		return "<Port:" \
-			+ " Name: (" + str(name) \
-			+ ") Status: (" + str(status) \
-			+ ") Enabled: (" + str(enabled) \
-			+ ")>"

--- a/core/systems/hardware/drm_card_port.gd
+++ b/core/systems/hardware/drm_card_port.gd
@@ -1,0 +1,132 @@
+extends Resource
+class_name DRMCardPort
+
+## GPU connector port state
+##
+## Represents the data contained in /sys/class/drm/cardX-YYYY and includes
+## an update function that can be called to update the state of the connector
+## port.
+
+## Mutex used for thread safety
+var mutex := Mutex.new()
+## Name of the port. E.g. HDMI-A-1
+var name: String
+## Full path to the port. E.g. /sys/class/drm/card1-HDMI-A-1
+var path: String
+## The connector id. E.g. /sys/class/drm/card1-HDMI-A-1/connector_id
+var connector_id := -1:
+	get:
+		mutex.lock()
+		var prop := connector_id
+		mutex.unlock()
+		return prop
+	set(v):
+		if connector_id == v:
+			return
+		mutex.lock()
+		connector_id = v
+		mutex.unlock()
+		emit_changed.call_deferred()
+## Whether or not the port is enabled
+var enabled := false:
+	get:
+		mutex.lock()
+		var prop := enabled
+		mutex.unlock()
+		return prop
+	set(v):
+		if enabled == v:
+			return
+		mutex.lock()
+		enabled = v
+		mutex.unlock()
+		emit_changed.call_deferred()
+## An array of valid modes (E.g. ["1024x768", "1920x1080"])
+var modes := PackedStringArray():
+	get:
+		mutex.lock()
+		var prop := modes
+		mutex.unlock()
+		return prop
+	set(v):
+		if modes == v:
+			return
+		mutex.lock()
+		modes = v
+		mutex.unlock()
+		emit_changed.call_deferred()
+## Status of the port (e.g. "connected")
+var status: String:
+	get:
+		mutex.lock()
+		var prop := status
+		mutex.unlock()
+		return prop
+	set(v):
+		if status == v:
+			return
+		mutex.lock()
+		status = v
+		mutex.unlock()
+		emit_changed.call_deferred()
+## Display power management signaling
+var dpms: bool:
+	get:
+		mutex.lock()
+		var prop := dpms
+		mutex.unlock()
+		return prop
+	set(v):
+		if dpms == v:
+			return
+		mutex.lock()
+		dpms = v
+		mutex.unlock()
+		emit_changed.call_deferred()
+
+## Updates the properties of the port
+func update() -> void:
+	connector_id = get_connector_id()
+	enabled = get_enabled()
+	modes = get_modes()
+	status = get_status()
+	dpms = get_dpms()
+
+func get_connector_id() -> int:
+	var id_str := _get_property("connector_id").strip_escapes()
+	if id_str.is_valid_int():
+		return id_str.to_int()
+	return -1
+
+func get_enabled() -> bool:
+	return _get_property("enabled").strip_escapes() == "enabled"
+
+func get_modes() -> PackedStringArray:
+	var found_modes := PackedStringArray()
+	var modes_str := _get_property("modes")
+	for mode in modes_str.split("\n"):
+		found_modes.append(mode.strip_escapes())
+	return found_modes
+	
+func get_status() -> String:
+	return _get_property("status").strip_escapes()
+
+func get_dpms() -> bool:
+	return _get_property("dpms").strip_escapes() == "On"
+
+func _get_property(prop: String) -> String:
+	var prop_path := "/".join([path, prop])
+	if not FileAccess.file_exists(prop_path):
+		return ""
+	var file := FileAccess.open(prop_path, FileAccess.READ)
+	var length := file.get_length()
+	var bytes := file.get_buffer(length)
+
+	return bytes.get_string_from_utf8()
+
+func _to_string() -> String:
+	return "<Port:" \
+		+ " Name: (" + str(name) \
+		+ ") Status: (" + str(status) \
+		+ ") Enabled: (" + str(enabled) \
+		+ ")>"

--- a/core/systems/hardware/hardware_manager_test.gd
+++ b/core/systems/hardware/hardware_manager_test.gd
@@ -1,0 +1,24 @@
+extends Test
+
+
+var hardware_manager := load("res://core/systems/hardware/hardware_manager.tres") as HardwareManager
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	hardware_manager.start_gpu_watch()
+	print(hardware_manager.cards)
+	print(hardware_manager.bios)
+	print(hardware_manager.cpu)
+	print(hardware_manager.gpu)
+	print(hardware_manager.kernel)
+	print(hardware_manager.product_name)
+	print(hardware_manager.vendor_name)
+
+	# Listen for port state changes
+	for card in hardware_manager.cards:
+		for port in card.get_ports():
+			port.changed.connect(_on_port_changed.bind(port))
+
+
+func _on_port_changed(port: DRMCardPort) -> void:
+	print("Port changed: ", port.name, " Status: ", port.status)

--- a/core/systems/hardware/hardware_manager_test.tscn
+++ b/core/systems/hardware/hardware_manager_test.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3 uid="uid://diee73tuxohmg"]
+
+[ext_resource type="Script" path="res://core/systems/hardware/hardware_manager_test.gd" id="1_kh5ys"]
+
+[node name="HardwareManagerTest" type="Node"]
+script = ExtResource("1_kh5ys")
+finish_after_ready = false


### PR DESCRIPTION
We never actually tested that signals on GPU port changes were working. This change fixes that, adds a test, and includes a `start_gpu_watch()` method to poll for GPU state changes in a thread.