### PR TITLE
fix(LaunchManager): disable STEAM_OVERLAY while game is running and overlay is not focused for performance-sensitive devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ deploy-ext: dist-ext ## Build and deploy systemd extension to remote device
 .PHONY: enable-debug
 enable-debug: ## Set OpenGamepadUI command to use remote debug on target device
 	ssh $(SSH_USER)@$(SSH_HOST) mkdir -p .config/environment.d
-	echo 'OGUICMD="opengamepadui --remote-debug tcp://127.0.0.1:6007"' | \
+	echo 'CLIENTCMD="opengamepadui --remote-debug tcp://127.0.0.1:6007"' | \
 		ssh $(SSH_USER)@$(SSH_HOST) bash -c \
 		'cat > .config/environment.d/opengamepadui-session.conf'
 


### PR DESCRIPTION
This change changes how we set the `STEAM_OVERLAY` atom while games are running. I found that there can be a drastic performance hit on low-spec devices if `STEAM_OVERLAY` is set to `1` while the game is running, so we now set `STEAM_OVERLAY` to `0` unless the user opens up a menu. On the Loki Zero, I saw a 2x performance improvement.