### PR TITLE
Custom godot fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ PREFIX ?= $(HOME)/.local
 CACHE_DIR ?= .cache
 ROOTFS ?= $(CACHE_DIR)/rootfs
 OGUI_VERSION ?= $(shell grep 'core = ' core/global/version.tres | cut -d '"' -f2)
-GODOT_VERSION ?= $(shell godot --version | grep -o '[0-9].*[0-9]\.' | sed 's/.$$//')
-GODOT_RELEASE ?= $(shell godot --version | grep -oP '^[0-9].*?[a-z]\.' | grep -oP '[a-z]+')
-GODOT_REVISION := $(GODOT_VERSION).$(GODOT_RELEASE)
 GODOT ?= /usr/bin/godot
+GODOT_VERSION ?= $(shell $(GODOT) --version | grep -o '[0-9].*[0-9]\.' | sed 's/.$$//')
+GODOT_RELEASE ?= $(shell $(GODOT) --version | grep -oP '^[0-9].*?[a-z]\.' | grep -oP '[a-z]+')
+GODOT_REVISION := $(GODOT_VERSION).$(GODOT_RELEASE)
 GAMESCOPE ?= /usr/bin/gamescope
 GAMESCOPE_CMD ?= $(GAMESCOPE) -e --xwayland-count 2 --
 


### PR DESCRIPTION
Respect GODOT variable for version / release determination

In Gentoo the godot binary is installed in /usr/bin/godot4 because can be insalled with godot3 at the same time.

Using `GODOT=/usr/bin/godot4 make` I seen two error messages abount godot not found.
This PR fixes the custom named godot usage.