### PR TITLE
fix(ExpandableCard): reset expansion where element visibility is lost

### DIFF
--- a/core/ui/card_ui/quick_bar/qb_card.gd
+++ b/core/ui/card_ui/quick_bar/qb_card.gd
@@ -38,7 +38,14 @@ func _ready() -> void:
 	# Do nothing if running in the editor
 	if Engine.is_editor_hint():
 		return
-	
+
+	# Auto-close when visibility is lost
+	var on_visibility_changed := func():
+		var grower := get_node("GrowerEffect") as GrowerEffect
+		grower.shrink()
+		is_toggled = false
+	hidden.connect(on_visibility_changed)
+
 	# Resize any children that are Control nodes
 	for child in content_container.get_children():
 		# If the node is a control, resize it based on its children

--- a/core/ui/components/expandable_card.gd
+++ b/core/ui/components/expandable_card.gd
@@ -36,6 +36,13 @@ func _ready() -> void:
 	# Do nothing if running in the editor
 	if Engine.is_editor_hint():
 		return
+
+	# Auto-close when visibility is lost
+	var on_visibility_changed := func():
+		var grower := get_node("GrowerEffect") as GrowerEffect
+		grower.shrink()
+		is_toggled = false
+	hidden.connect(on_visibility_changed)
 	
 	# Resize any children that are Control nodes
 	for child in content_container.get_children():


### PR DESCRIPTION
This change fixes a bug where Quick Bar Menu cards will remain expanded when it is re-opened.