### PR TITLE
fix(SystemdExt): update systemd-ext to include inputplumber dependencies

### DIFF
--- a/core/platform/actions/start_inputplumber.gd
+++ b/core/platform/actions/start_inputplumber.gd
@@ -1,0 +1,11 @@
+extends PlatformAction
+class_name ActionStartInputPlumber
+
+const INPUT_PLUMBER_PATH := "/usr/share/opengamepadui/scripts/manage_input"
+
+
+func execute() -> void:
+	logger.info("Starting InputPlumber")
+	var cmd := CommandSync.new(INPUT_PLUMBER_PATH, ["startInputPlumber"])
+	if cmd.execute() != OK:
+		logger.warn("Failed to start InputPlumber: " + cmd.stdout)

--- a/core/platform/actions/start_powerstation.gd
+++ b/core/platform/actions/start_powerstation.gd
@@ -1,7 +1,7 @@
 extends PlatformAction
 class_name ActionStartPowerStation
 
-const POWERTOOLS_PATH := "/usr/share/opengamepadui/scripts/powertools"
+const POWERTOOLS_PATH := "/usr/share/opengamepadui/scripts/manage_input"
 
 
 func execute() -> void:

--- a/core/platform/handheld/steamdeck/steamdeck.tres
+++ b/core/platform/handheld/steamdeck/steamdeck.tres
@@ -1,8 +1,16 @@
-[gd_resource type="Resource" script_class="HandheldPlatform" load_steps=4 format=3 uid="uid://dx0ykcjvufix"]
+[gd_resource type="Resource" script_class="HandheldPlatform" load_steps=8 format=3 uid="uid://dx0ykcjvufix"]
 
 [ext_resource type="Script" path="res://core/platform/handheld/handheld_platform.gd" id="1_f6nrl"]
 [ext_resource type="Texture2D" uid="uid://cvyo2q5qjpamv" path="res://assets/images/gamepad/steamdeck/diagram.png" id="1_juvkj"]
 [ext_resource type="Texture2D" uid="uid://dd8meysn3x77u" path="res://assets/images/platform/steamdeck.png" id="2_tane6"]
+[ext_resource type="Script" path="res://core/platform/actions/start_inputplumber.gd" id="4_s8wpf"]
+[ext_resource type="Script" path="res://core/platform/actions/start_powerstation.gd" id="5_0hrnj"]
+
+[sub_resource type="Resource" id="Resource_6u3hp"]
+script = ExtResource("4_s8wpf")
+
+[sub_resource type="Resource" id="Resource_us7cn"]
+script = ExtResource("5_0hrnj")
 
 [resource]
 script = ExtResource("1_f6nrl")
@@ -10,5 +18,5 @@ image = ExtResource("2_tane6")
 diagram = ExtResource("1_juvkj")
 icon_mappings = Array[Resource("res://core/platform/handheld/handheld_icon_mapping.gd")]([])
 name = ""
-startup_actions = Array[Resource("res://core/platform/actions/platform_action.gd")]([])
+startup_actions = Array[Resource("res://core/platform/actions/platform_action.gd")]([SubResource("Resource_6u3hp"), SubResource("Resource_us7cn")])
 shutdown_actions = Array[Resource("res://core/platform/actions/platform_action.gd")]([])

--- a/docs/install/deck_install_script.sh
+++ b/docs/install/deck_install_script.sh
@@ -112,7 +112,7 @@ fi
 (
 	echo "15"
 	echo "# Creating file structure"
-	sudo -u $SUDO_USER mkdir -p "${EXTENSIONS_FOLDER}" "${USER_DIR}/.config/systemd/user"
+	sudo -u $SUDO_USER mkdir -p "${EXTENSIONS_FOLDER}" "${USER_DIR}/.config/systemd/user" "${USER_DIR}/.local/bin"
 	if ! [ -s /var/lib/extensions ]; then
 		ln -s "${EXTENSIONS_FOLDER}" /var/lib/extensions
 	fi
@@ -125,6 +125,8 @@ fi
 	echo "# Installing systemd extension updater"
 	curl -L https://raw.githubusercontent.com/ShadowBlip/OpenGamepadUI/main/rootfs/usr/lib/systemd/user/systemd-sysext-updater.service -o "${USER_DIR}/.config/systemd/user/systemd-sysext-updater.service"
 	chown $SUDO_USER "${USER_DIR}/.config/systemd/user/systemd-sysext-updater.service"
+	curl -L https://raw.githubusercontent.com/ShadowBlip/OpenGamepadUI/main/rootfs/usr/share/opengamepadui/scripts/update_systemd_ext.sh -o "${USER_DIR}/.local/bin"
+	chown $SUDO_USER "${USER_DIR}/.local/bin/update_systemd_ext.sh"
 
 	echo "45"
 	echo "# Installing OpenGamepadUI extension"

--- a/rootfs/usr/lib/systemd/user/systemd-sysext-updater.service
+++ b/rootfs/usr/lib/systemd/user/systemd-sysext-updater.service
@@ -4,7 +4,7 @@ After=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/bash -c "cd ~/.var/lib/extensions && rm -rf squashfs-root && unsquashfs opengamepadui.raw && grep '^ID=' /etc/os-release > squashfs-root/usr/lib/extension-release.d/extension-release.opengamepadui && grep '^VERSION_ID=' /etc/os-release >> squashfs-root/usr/lib/extension-release.d/extension-release.opengamepadui && rm opengamepadui.raw && mksquashfs squashfs-root opengamepadui.raw"
+ExecStart=/usr/bin/bash -c "~/.local/bin/update_systemd_ext.sh"
 
 [Install]
 WantedBy=default.target

--- a/rootfs/usr/share/opengamepadui/scripts/manage_input
+++ b/rootfs/usr/share/opengamepadui/scripts/manage_input
@@ -8,7 +8,7 @@ fi
 
 turbo_takeover() {
 	value=${1}
-	echo ${value} >/sys/devices/platform/oxp-platform/tt_toggle
+	echo "${value}" >/sys/devices/platform/oxp-platform/tt_toggle
 }
 
 if [[ $1 == "turbo_takeover" ]]; then
@@ -16,5 +16,13 @@ if [[ $1 == "turbo_takeover" ]]; then
 		echo "Turbo toggle does not exist."
 		exit 1
 	fi
-	turbo_takeover $2
+	turbo_takeover "$2"
+fi
+
+if [[ $1 == "startInputPlumber" ]]; then
+	systemctl enable --now inputplumber
+fi
+
+if [[ $1 == "startPowerStation" ]]; then
+	systemctl enable --now powerstation
 fi

--- a/rootfs/usr/share/opengamepadui/scripts/update_systemd_ext.sh
+++ b/rootfs/usr/share/opengamepadui/scripts/update_systemd_ext.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+cd ~/.var/lib/extensions
+rm -rf squashfs-root
+unsquashfs -no-xattrs opengamepadui.raw
+grep '^ID=' /etc/os-release >squashfs-root/usr/lib/extension-release.d/extension-release.opengamepadui
+grep '^VERSION_ID=' /etc/os-release >>squashfs-root/usr/lib/extension-release.d/extension-release.opengamepadui
+rm -f opengamepadui.raw
+mksquashfs squashfs-root opengamepadui.raw


### PR DESCRIPTION
This change fixes issues with the systemd extension and updater service. It now includes InputPlumber (and dependencies), as well as platform actions to start InputPlumber and PowerStation.

Fixes #303