### PR TITLE
fix(StateMachine): Prevent global state stack from going null.

### DIFF
--- a/assets/state/state_machines/first_boot_network_state_machine.tres
+++ b/assets/state/state_machines/first_boot_network_state_machine.tres
@@ -5,3 +5,4 @@
 [resource]
 script = ExtResource("1_iwio6")
 logger_name = "NetworkOOBE"
+minimum_states = 0

--- a/assets/state/state_machines/first_boot_state_machine.tres
+++ b/assets/state/state_machines/first_boot_state_machine.tres
@@ -5,3 +5,4 @@
 [resource]
 script = ExtResource("1_8ewnv")
 logger_name = "FirstBoot"
+minimum_states = 0

--- a/assets/state/state_machines/game_settings_state_machine.tres
+++ b/assets/state/state_machines/game_settings_state_machine.tres
@@ -5,3 +5,4 @@
 [resource]
 script = ExtResource("1_ilq52")
 logger_name = "GameSettingsStateMachine"
+minimum_states = 0

--- a/assets/state/state_machines/gamepad_settings_state_machine.tres
+++ b/assets/state/state_machines/gamepad_settings_state_machine.tres
@@ -5,3 +5,4 @@
 [resource]
 script = ExtResource("1_hgufk")
 logger_name = "StateMachine"
+minimum_states = 0

--- a/assets/state/state_machines/plugin_settings_state_machine.tres
+++ b/assets/state/state_machines/plugin_settings_state_machine.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://bnwdyr66wnxaw"]
+[gd_resource type="Resource" script_class="StateMachine" load_steps=2 format=3 uid="uid://bnwdyr66wnxaw"]
 
 [ext_resource type="Script" path="res://core/systems/state/state_machine.gd" id="1_20omy"]
 
 [resource]
 script = ExtResource("1_20omy")
 logger_name = "PluginSettingsStateMachine"
+minimum_states = 0

--- a/assets/state/state_machines/quick_bar_state_machine.tres
+++ b/assets/state/state_machines/quick_bar_state_machine.tres
@@ -5,3 +5,4 @@
 [resource]
 script = ExtResource("1_k2cku")
 logger_name = "QuickBarStateMachine"
+minimum_states = 0

--- a/assets/state/state_machines/settings_state_machine.tres
+++ b/assets/state/state_machines/settings_state_machine.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://iqrotrmq62i6"]
+[gd_resource type="Resource" script_class="StateMachine" load_steps=2 format=3 uid="uid://iqrotrmq62i6"]
 
 [ext_resource type="Script" path="res://core/systems/state/state_machine.gd" id="1_7ufyt"]
 
 [resource]
 script = ExtResource("1_7ufyt")
 logger_name = "SettingsStateMachine"
+minimum_states = 0

--- a/core/global/launch_manager.gd
+++ b/core/global/launch_manager.gd
@@ -60,7 +60,6 @@ var should_manage_overlay := true
 
 # Connect to Gamescope signals
 func _init() -> void:
-
 	# When window focus changes, update the current app and gamepad profile
 	var on_focus_changed := func(from: int, to: int):
 		logger.info("Window focus changed from " + str(from) + " to: " + str(to))

--- a/core/systems/input/back_input_handler.gd
+++ b/core/systems/input/back_input_handler.gd
@@ -42,6 +42,4 @@ func _input(event: InputEvent) -> void:
 	get_viewport().set_input_as_handled()
 
 	# Pop the state machine stack to go back
-	if state_machine.stack_length() > minimum_states:
-		state_machine.pop_state()
-		return
+	state_machine.pop_state()

--- a/core/systems/state/state_machine_test.gd
+++ b/core/systems/state/state_machine_test.gd
@@ -5,6 +5,7 @@ var state_machine: StateMachine
 
 func before_each() -> void:
 	state_machine = StateMachine.new()
+	state_machine.minimum_states = 0
 	watch_signals(state_machine)
 
 

--- a/core/systems/state/state_updater_test.gd
+++ b/core/systems/state/state_updater_test.gd
@@ -10,6 +10,7 @@ var node: Button
 func before_each() -> void:
 	# Create a state machine and state
 	state_machine = StateMachine.new()
+	state_machine.minimum_states = 0
 	state = State.new()
 
 	# Create and configure the state updater

--- a/core/systems/state/state_watcher_test.gd
+++ b/core/systems/state/state_watcher_test.gd
@@ -10,6 +10,7 @@ var node: Node
 func before_each() -> void:
 	# Create a state machine and state
 	state_machine = StateMachine.new()
+	state_machine.minimum_states = 0
 	state = State.new()
 
 	# Create a state watcher

--- a/core/ui/card_ui/main-menu/main_menu_test.gd
+++ b/core/ui/card_ui/main-menu/main_menu_test.gd
@@ -23,8 +23,7 @@ func before_each() -> void:
 func after_each() -> void:
 	if headless:
 		return
-	while state_machine.stack_length() > 0:
-		state_machine.pop_state()
+	state_machine.clear_states()
 
 
 # Stop all threads to prevent crashing


### PR DESCRIPTION
- Adds `@export var minimum_states: int = 1` to StateMachine. state_machine.pop_state() will never go below this value.
- Sets all non-global StateMachines minimum states to 0.
- Remove code no longer needed in overlay_input_manager that prevented dropping to null states.
- While at it, change method comments in StateMachine to be used in automatic documentation formatting.