### PR TITLE
fix(Input): add limited input mappings when not running InputPlumber

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -109,7 +109,8 @@ ui_down={
 }
 ogui_guide={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":8,"pressure":0.0,"pressed":true,"script":null)
+]
 }
 ogui_tab_right={
 "deadzone": 0.5,
@@ -123,7 +124,8 @@ ogui_tab_left={
 }
 ogui_south={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":true,"script":null)
+]
 }
 ogui_north={
 "deadzone": 0.5,
@@ -136,6 +138,7 @@ ogui_west={
 ogui_east={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 ogui_guide_action={
@@ -161,6 +164,7 @@ ogui_back={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194308,"key_label":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 ogui_left_trigger={


### PR DESCRIPTION
Thinking about it more, I think having limited input mappings for when InputPlumber is not running (or does not support a specific controller) is nice to have. This partially reverts https://github.com/ShadowBlip/OpenGamepadUI/commit/e62e2964f11705a353937c6b8fde92c784e414a4 but just adds `South`, `East`, and `Guide` to avoid the original issue with https://github.com/godotengine/godot/issues/87112