### PR TITLE
fix(Input): disable/enable Godot input based on InputPlumber running

### DIFF
--- a/core/systems/threading/shared_thread.gd
+++ b/core/systems/threading/shared_thread.gd
@@ -20,6 +20,7 @@ var process_funcs: Array[Callable] = []
 var scheduled_funcs: Array[ScheduledTask] = []
 var one_shots: Array[Callable] = []
 var last_time: int
+var task_id_count := 0
 var logger := Log.get_logger("SharedThread", Log.LEVEL.INFO)
 
 ## Name of the thread group
@@ -121,40 +122,46 @@ func exec(method: Callable) -> Variant:
 	return out[1]
 
 
-## Calls the given method from the thread after 'wait_time_ms' has passed.
-func scheduled_exec(method: Callable, wait_time_ms: int) -> void:
+## Calls the given method from the thread after 'wait_time_ms' has passed. By
+## default, this method will execute as a "oneshot" task. Optionally, the "task_type"
+## parameter can be set to "RECURRING" if this task should run every 'wait_time_ms'.
+func scheduled_exec(method: Callable, wait_time_ms: int, task_type: ScheduledTaskType = ScheduledTaskType.ONESHOT) -> int:
 	var task := ScheduledTask.new()
+	mutex.lock()
+	var task_id := task_id_count
+	task_id_count += 1
+	mutex.unlock()
+
+	task.task_id = task_id
 	task.method = method
 	task.wait_time_ms = wait_time_ms
 	task.start_time = Time.get_ticks_msec()
+	task.task_type = task_type
+
 	mutex.lock()
 	scheduled_funcs.append(task)
 	mutex.unlock()
 
+	return task_id
 
-## Cancels a given Sheduled Task before it is executed.
-func cancel_scheduled_exec(task: ScheduledTask) -> void:
+
+## Cancels a given Sheduled Task
+func cancel_scheduled_exec(task_id: int) -> void:
 	mutex.lock()
 	var all_sched_funcs := scheduled_funcs.duplicate()
 	mutex.unlock()
-	if task not in all_sched_funcs:
-		logger.warn("Scheduled Task " + task.method.get_method() + " canceled but not found in scheduled functions."  )
+	var found_task: ScheduledTask
+	for task in all_sched_funcs:
+		if task.task_id != task_id:
+			continue
+		found_task = task
+		break
+	if not found_task:
+		logger.warn("Scheduled Task with ID", task_id, "canceled but not found in scheduled functions.")
 		return
 	mutex.lock()
-	scheduled_funcs.erase(task)
+	scheduled_funcs.erase(found_task)
 	mutex.unlock()
-
-
-## Finds all SheduledTask's who's method matches the given method.
-func find_scheduled_exec(method: Callable) -> Array[ScheduledTask]:
-	mutex.lock()
-	var all_sched_funcs := scheduled_funcs.duplicate()
-	mutex.unlock()
-	var matching_tasks: Array[ScheduledTask] = []
-	for task in all_sched_funcs:
-		if task.method == method:
-			matching_tasks.append(task)
-	return matching_tasks
 
 
 ## Adds the given method to the thread process loop. This method will be called
@@ -274,9 +281,12 @@ func _process(delta: float) -> void:
 			continue
 		_set_executing_task(ExecutingTask.from_callable(method))
 		method.call()
-		mutex.lock()
-		scheduled_funcs.erase(task)
-		mutex.unlock()
+		if task.task_type == ScheduledTaskType.ONESHOT:
+			mutex.lock()
+			scheduled_funcs.erase(task)
+			mutex.unlock()
+		if task.task_type == ScheduledTaskType.RECURRING:
+			task.start_time = current_time
 		_set_executing_task(null)
 
 
@@ -307,15 +317,28 @@ func get_target_frame_time() -> int:
 	return int((1.0 / target_tick_rate) * 1000000.0)
 
 
+## Determines how scheduled tasks should be executed. Scheduled tasks can be
+## run as "oneshot" tasks, which will only be run once, or they can be scheduled
+## to run as recurring tasks.
+enum ScheduledTaskType {
+	## Run the scheduled task once after wait period
+	ONESHOT = 0,
+	## Run the scheduled task every wait period interval
+	RECURRING = 1,
+}
+
+
 ## Container for holding a scheduled task to run in a thread
-class ScheduledTask:
+class ScheduledTask extends RefCounted:
+	var task_id: int
 	var start_time: int
 	var wait_time_ms: int
 	var method: Callable
+	var task_type: ScheduledTaskType
 
 
 ## Container for holding information about the currently executing task
-class ExecutingTask:
+class ExecutingTask extends RefCounted:
 	var object: String
 	var method: String
 	var args: Array

--- a/project.godot
+++ b/project.godot
@@ -115,11 +115,13 @@ ogui_guide={
 ogui_tab_right={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194324,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":10,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 ogui_tab_left={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":true,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194323,"key_label":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":9,"pressure":0.0,"pressed":true,"script":null)
 ]
 }
 ogui_south={
@@ -129,11 +131,13 @@ ogui_south={
 }
 ogui_north={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":2,"pressure":0.0,"pressed":true,"script":null)
+]
 }
 ogui_west={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":3,"pressure":0.0,"pressed":true,"script":null)
+]
 }
 ogui_east={
 "deadzone": 0.5,
@@ -169,11 +173,13 @@ ogui_back={
 }
 ogui_left_trigger={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
+]
 }
 ogui_right_trigger={
 "deadzone": 0.5,
-"events": []
+"events": [Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":5,"axis_value":1.0,"script":null)
+]
 }
 ogui_modifier={
 "deadzone": 0.5,


### PR DESCRIPTION
Fixes #374

This change adds a task that will monitor the running state of InputPlumber. If InputPlumber is running, it disables the Godot input map and relies solely on InputPlumber for gamepad input. If InputPlumber is stopped, it restores the Godot input map so input can be processed by Godot's input system instead.