### PR TITLE
fix(Tabs Container): remove old refs to LB/RB textures

### DIFF
--- a/core/ui/components/tabs_header.gd
+++ b/core/ui/components/tabs_header.gd
@@ -11,8 +11,6 @@ var current_tab: TabLabel
 
 @onready var l_sep := $%LSeparator
 @onready var r_sep := $%RSeparator
-@onready var l_texture := $%TextureLB
-@onready var r_texture := $%TextureRB
 @onready var container := $%TabLabelContainer
 
 


### PR DESCRIPTION
Fixes these errors:
![image](https://github.com/user-attachments/assets/f437c6be-959a-4ed1-a42f-7e29bbd6bb55)
