### PR TITLE
Fix gamepad settings null string assignment

### DIFF
--- a/core/systems/threading/shared_thread.gd
+++ b/core/systems/threading/shared_thread.gd
@@ -362,7 +362,6 @@ class ExecutingTask extends RefCounted:
 	static func from_callable(callable: Callable) -> ExecutingTask:
 		var task := ExecutingTask.new()
 		task.object = str(callable.get_object())
-		task.method = callable.get_method()
 		task.args = callable.get_bound_arguments()
 		return task
 
@@ -373,4 +372,4 @@ class ExecutingTask extends RefCounted:
 		return task
 
 	func _to_string() -> String:
-		return "{0}.{1}({2})".format([self.object, self.method, str(self.args)])
+		return "{0}.func({2})".format([self.object, str(self.args)])

--- a/core/ui/card_ui/gamepad/gamepad_settings.gd
+++ b/core/ui/card_ui/gamepad/gamepad_settings.gd
@@ -71,8 +71,8 @@ func _ready() -> void:
 	gamepad_type_dropdown.item_selected.connect(on_gamepad_selected)
 
 	# Load the default profile
-	var profile_path = settings_manager.get_value("input", "gamepad_profile")
-	profile_gamepad = settings_manager.get_value("input", "gamepad_profile_target")
+	var profile_path = settings_manager.get_value("input", "gamepad_profile", "")
+	profile_gamepad = settings_manager.get_value("input", "gamepad_profile_target", "")
 	for gamepad in input_plumber.composite_devices:
 			_set_gamepad_profile(gamepad, profile_path)
 
@@ -604,7 +604,7 @@ func _set_gamepad_profile(gamepad: InputPlumber.CompositeDevice, profile_path: S
 
 		# If no library item was set with the state, then use the default
 		if not library_item:
-			profile_path = settings_manager.get_value("input", "gamepad_profile")
+			profile_path = settings_manager.get_value("input", "gamepad_profile", "") as String
 		else:
 			profile_path = settings_manager.get_library_value(library_item, "gamepad_profile", "")
 


### PR DESCRIPTION
This change also removes tracking the method name in `SharedThread` to stop these spam errors:
![image](https://github.com/user-attachments/assets/666f3a47-afad-418e-adbc-0f53232f4168)
