### PR TITLE
fix(Slider): add option to show/hide decimal values in sliders

### DIFF
--- a/core/ui/common/settings/display_settings_menu.tscn
+++ b/core/ui/common/settings/display_settings_menu.tscn
@@ -63,6 +63,7 @@ value = 1.0
 max_value = 3.0
 min_value = 0.2
 step = 0.02
+show_decimal = true
 
 [node name="OverlayLabel" parent="VBoxContainer" instance=ExtResource("3_nmfgp")]
 layout_mode = 2

--- a/core/ui/components/battery_container.gd
+++ b/core/ui/components/battery_container.gd
@@ -37,7 +37,7 @@ func _on_update_device(item: UPowerDevice):
 	var capacity := item.percentage
 	var state := item.state
 	battery_icon.texture = get_capacity_texture(capacity, state)
-	battery_label.text = str(capacity)+"%"
+	battery_label.text = str(int(capacity))+"%"
 	if capacity > 5:
 		battery_icon.modulate = Color(1, 1, 1)
 	else:

--- a/core/ui/components/slider.gd
+++ b/core/ui/components/slider.gd
@@ -20,7 +20,7 @@ signal value_changed(value: float)
 	set(v):
 		value = v
 		if label_value:
-			label_value.text = str(v)
+			label_value.text = _get_value_str()
 		if slider:
 			slider.value = v
 		value_changed.emit(v)
@@ -54,6 +54,11 @@ signal value_changed(value: float)
 			slider.editable = v
 		notify_property_list_changed()
 
+@export var show_decimal: bool = false:
+	set(v):
+		show_decimal = v
+		notify_property_list_changed()
+
 @export var tick_count := 0
 @export var separator_visible: bool = false
 
@@ -68,7 +73,7 @@ signal value_changed(value: float)
 func _ready() -> void:
 	focus_entered.connect(_grab_focus)
 	label.text = text
-	label_value.text = str(slider.value)
+	label_value.text = _get_value_str()
 	hsep.visible = separator_visible
 	slider.value_changed.connect(_on_value_changed)
 	slider.value = value
@@ -92,7 +97,7 @@ func _ready() -> void:
 		drag_started.emit()
 	slider.drag_ended.connect(on_drag_started)
 	var on_changed := func():
-		label_value.text = str(slider.value)
+		label_value.text = _get_value_str()
 		changed.emit()
 	slider.changed.connect(on_changed)
 
@@ -116,6 +121,14 @@ func _on_value_changed(v: float) -> void:
 # Override focus grabbing to grab the slider
 func _grab_focus() -> void:
 	slider.grab_focus()
+
+
+# Get the current value as a string
+func _get_value_str() -> String:
+	if show_decimal:
+		return str(slider.value)
+	else:
+		return str(int(slider.value))
 
 
 # Override certain properties and pass them to child objects


### PR DESCRIPTION
This change adds an option for sliders to show the decimal value or not (defaults to `false`). This is now required due to changes in Godot 4.4 which includes the decimal value by default when converting floats to strings.