### PR TITLE
refactor: simplify Steam pid discovery

### DIFF
--- a/core/systems/launcher/running_app.gd
+++ b/core/systems/launcher/running_app.gd
@@ -579,17 +579,8 @@ func is_steam_window(window_id: int) -> bool:
 
 ## Finds the steam process so it can be killed when a game closes
 func find_steam() -> int:
-	var child_pids := get_child_pids()
-	for child_pid in child_pids:
-		var pid_info := Reaper.get_pid_status(child_pid)
-		if not "Name" in pid_info:
-			continue
-		var process_name := pid_info["Name"] as String
-		if process_name == "steam":
-			logger.trace("Found steam PID: " + str(child_pid))
-			return child_pid
-
-	return -1
+	var steam_pid := OS.get_environment("HOME") + "/.steam/steam.pid"
+	return FileAccess.open(steam_pid, FileAccess.READ).get_as_text().to_int()
 
 
 func _to_string() -> String:

--- a/core/systems/launcher/running_app.gd
+++ b/core/systems/launcher/running_app.gd
@@ -579,18 +579,18 @@ func is_steam_window(window_id: int) -> bool:
 
 ## Finds the steam process so it can be killed when a game closes
 func find_steam() -> int:
-	var steam_pid := OS.get_environment("HOME") + "/.steam/steam.pid"
-	if not FileAccess.file_exists(steam_pid):
+	var steam_pid_path := OS.get_environment("HOME") + "/.steam/steam.pid"
+	if not FileAccess.file_exists(steam_pid_path):
 		return -1
 
-	var pid := FileAccess.open(steam_pid, FileAccess.READ).get_as_text()
-	if not DirAccess.dir_exists_absolute("/proc/" + pid + "/fd"):
+	var steam_pid := FileAccess.open(steam_pid_path, FileAccess.READ).get_as_text()
+	if not DirAccess.dir_exists_absolute("/proc/" + steam_pid + "/fd"):
 		return -1
 
-	for fd in DirAccess.get_files_at("/proc/" + pid + "/fd"):
+	for fd in DirAccess.get_files_at("/proc/" + steam_pid + "/fd"):
 		if FileAccess.open(fd, FileAccess.READ).get_path_absolute() != steam_pid:
 			continue
-		return pid.to_int()
+		return steam_pid.to_int()
 
 	return -1
 

--- a/core/systems/launcher/running_app.gd
+++ b/core/systems/launcher/running_app.gd
@@ -587,8 +587,9 @@ func find_steam() -> int:
 	if not DirAccess.dir_exists_absolute("/proc/" + steam_pid + "/fd"):
 		return -1
 
+	var steam_pipe := OS.get_environment("HOME") + "/.steam/steam.pipe"
 	for fd in DirAccess.get_files_at("/proc/" + steam_pid + "/fd"):
-		if FileAccess.open(fd, FileAccess.READ).get_path_absolute() != steam_pid:
+		if FileAccess.open(fd, FileAccess.READ).get_path_absolute() != steam_pipe:
 			continue
 		return steam_pid.to_int()
 

--- a/core/systems/launcher/running_app.gd
+++ b/core/systems/launcher/running_app.gd
@@ -580,7 +580,19 @@ func is_steam_window(window_id: int) -> bool:
 ## Finds the steam process so it can be killed when a game closes
 func find_steam() -> int:
 	var steam_pid := OS.get_environment("HOME") + "/.steam/steam.pid"
-	return FileAccess.open(steam_pid, FileAccess.READ).get_as_text().to_int()
+	if not FileAccess.file_exists(steam_pid):
+		return -1
+
+	var pid := FileAccess.open(steam_pid, FileAccess.READ).get_as_text()
+	if not DirAccess.dir_exists_absolute("/proc/" + pid + "/fd"):
+		return -1
+
+	for fd in DirAccess.get_files_at("/proc/" + pid + "/fd"):
+		if FileAccess.open(fd, FileAccess.READ).get_path_absolute() != steam_pid:
+			continue
+		return pid.to_int()
+
+	return -1
 
 
 func _to_string() -> String:


### PR DESCRIPTION
We can simplify finding Steam's PID by simply reading $HOME/.steam/steam.pid for apps that are run through Steam rather than traversing procfs for a process name. The file is created and populated by the official Steam client, and I think this should be fine for the current app states. 
