### PR TITLE
fix(NixOS): add OS update branch selector

### DIFF
--- a/core/ui/components/dropdown.tscn
+++ b/core/ui/components/dropdown.tscn
@@ -36,3 +36,4 @@ layout_mode = 2
 fit_to_longest_item = false
 item_count = 1
 popup/item_0/text = "None"
+popup/item_0/id = 0


### PR DESCRIPTION
This change adds a dropdown in the update section of the settings menu for NixOS platforms that allows users to select the OS branch to use for updates.