### PR TITLE
fix(Focus): re-focus ui if focus is lost but a direction is pressed

### DIFF
--- a/core/systems/input/focus_group.gd
+++ b/core/systems/input/focus_group.gd
@@ -55,7 +55,7 @@ func _ready():
 	
 	# Try to find a focus node if one was not specified
 	if not current_focus or not current_focus.is_visible_in_tree():
-		current_focus = _find_focusable(parent.get_children(), parent)
+		current_focus = find_focusable(parent.get_children(), parent)
 
 
 ## Recalculate the focus neighbors of the container's children
@@ -118,7 +118,7 @@ func grab_focus() -> void:
 	if not is_focused():
 		focus_stack.push(self)
 	if not current_focus:
-		current_focus = _find_focusable(parent.get_children(), parent)
+		current_focus = find_focusable(parent.get_children(), parent)
 		logger.trace("Found focus node: " + str(current_focus))
 	if current_focus:
 		logger.info(parent.name + " grabbing focus on node: " + current_focus.name)
@@ -225,7 +225,8 @@ func _find_child_focus_group(nodes: Array[Node], root: Node = null) -> FocusGrou
 
 
 # Recursively searches the given node children for a focusable node.
-func _find_focusable(nodes: Array[Node], root: Node = null) -> Node:
+static func find_focusable(nodes: Array[Node], root: Node = null) -> Node:
+	var logger := Log.get_logger("FocusGroup", Log.LEVEL.INFO)
 	if nodes.size() == 0:
 		logger.trace("Node has no children to check.")
 		return null
@@ -236,7 +237,7 @@ func _find_focusable(nodes: Array[Node], root: Node = null) -> Node:
 		# If the node is not a Control, try to find a child control node
 		if not node is Control:
 			logger.trace("Node not control. Checking children.")
-			focusable = _find_focusable(node.get_children(), root)
+			focusable = find_focusable(node.get_children(), root)
 			if focusable:
 				return focusable
 			logger.trace("Node: " + node.name + " has no more children to check.")
@@ -254,7 +255,7 @@ func _find_focusable(nodes: Array[Node], root: Node = null) -> Node:
 			return node
 		# Otherwise try and recursively find a child that can be focused
 		logger.trace("Node: " + node.name + " is not focusable. Checking its children.")
-		focusable = _find_focusable(node.get_children(), root)
+		focusable = find_focusable(node.get_children(), root)
 		if focusable:
 			return focusable
 	logger.trace("Node has no focusable children.")

--- a/core/systems/input/input_manager.gd
+++ b/core/systems/input/input_manager.gd
@@ -131,6 +131,16 @@ func _input(event: InputEvent) -> void:
 				return
 			actions_pressed[action] = value
 
+	# If no focus exists and a direction is pressed, try to find a new focus
+	if event.is_action("ui_left") or event.is_action("ui_right") or event.is_action("ui_up") or event.is_action("ui_down"):
+		if not get_viewport().gui_get_focus_owner():
+			logger.debug("Focus lost. Finding something to focus.")
+			var new_focus := _find_focus()
+			if new_focus:
+				logger.debug("Found something to focus:", new_focus)
+				new_focus.grab_focus.call_deferred()
+				return
+
 	# Handle guide button inputs
 	if event.is_action("ogui_guide"):
 		_guide_input(event)
@@ -206,6 +216,16 @@ func _input(event: InputEvent) -> void:
 	elif event.is_action_released("ogui_north"):
 		logger.debug("North released on its own.")
 		action_release(dbus_path, "ogui_search")
+
+
+## Find a node to grab focus on if no focus exists
+func _find_focus() -> Node:
+	var main := get_tree().get_first_node_in_group("main")
+	if not main:
+		logger.debug("Unable to find main node to find focus. Is there a node in the 'main' node group?")
+		return null
+
+	return FocusGroup.find_focusable([main])
 
 
 ## Handle guide button events and determine whether this is a guide action

--- a/core/systems/input/overlay_mode_input_manager.gd
+++ b/core/systems/input/overlay_mode_input_manager.gd
@@ -98,6 +98,16 @@ func _input(event: InputEvent) -> void:
 			return
 		actions_pressed[action] = value
 
+	# If no focus exists and a direction is pressed, try to find a new focus
+	if event.is_action("ui_left") or event.is_action("ui_right") or event.is_action("ui_up") or event.is_action("ui_down"):
+		if not get_viewport().gui_get_focus_owner():
+			logger.debug("Focus lost. Finding something to focus.")
+			var new_focus := _find_focus()
+			if new_focus:
+				logger.debug("Found something to focus:", new_focus)
+				new_focus.grab_focus.call_deferred()
+				return
+
 	# Handle guide button inputs
 	if event.is_action("ogui_guide_ov"):
 		_guide_input(event)
@@ -248,6 +258,16 @@ func _input(event: InputEvent) -> void:
 		logger.debug("East released on its own.")
 		action_release(dbus_path, "ogui_tab_left")
 		get_viewport().set_input_as_handled()
+
+
+## Find a node to grab focus on if no focus exists
+func _find_focus() -> Node:
+	var main := get_tree().get_first_node_in_group("main")
+	if not main:
+		logger.debug("Unable to find main node to find focus. Is there a node in the 'main' node group?")
+		return null
+
+	return FocusGroup.find_focusable([main])
 
 
 ## Handle guide button events and determine whether this is a guide action


### PR DESCRIPTION
In some cases, a user may find themselves in a position where no UI element is currently focused and will be unable to use the joystick or d-pad to regain control. This change updates the `InputManager` to find a focusable node and focus it if a direction is pressed and nothing is focused, ensuring that the user will always be able to use gamepad controls.

Because the logic already exists for recursively finding a focusable node in `FocusGroup`, this change updates the `find_focusable` method in that class to be a public static method so it can be used elsewhere.