### PR TITLE
fix(Plugins): use latest compatible version of plugins on download

### DIFF
--- a/core/ui/card_ui/settings/plugin_store_menu.gd
+++ b/core/ui/card_ui/settings/plugin_store_menu.gd
@@ -50,29 +50,57 @@ func _populate_plugin_store_items(grid: Container, plugin_items: Dictionary):
 	for plugin_id in plugin_items.keys():
 		if plugin_id in plugin_nodes:
 			continue
-			
 		var plugin: Dictionary = plugin_items[plugin_id]
+		_populate_plugin_store_item(grid, plugin_id, plugin)
 
-		# Build the store item
-		var store_item := plugin_store_card_scene.instantiate()
-		store_item.visible = false
-		store_item.download_url = plugin["archive.url"]
-		store_item.project_url = plugin["plugin.link"]
-		store_item.sha256 = plugin["archive.sha256"]
-		store_item.plugin_id = plugin["plugin.id"]
-		store_item.name = store_item.plugin_id
-		grid.add_child(store_item)
-		store_item.plugin_name_label.text = plugin["plugin.name"]
-		store_item.summary_label.text = plugin["plugin.summary"]
-		
-		# Load the plugin image
-		if len(plugin["store.images"]) > 0:
-			var image = await http_image.fetch(plugin["store.images"][0])
-			if image != null:
-				store_item.plugin_texture.texture = image
-		
-		# Add the store item
-		store_item.visible = true
+
+func _populate_plugin_store_item(grid: Container, plugin_id: String, plugin: Dictionary) -> void:
+	if plugin_id in plugin_nodes:
+		return
+
+	# Get the plugin package details
+	var download_url := plugin["archive.url"] as String
+	var hash := plugin["archive.sha256"] as String
+	var min_api_version := plugin["plugin.min-api-version"] as String
+
+	# If the latest plugin is incompatible with the current version of OpenGamepadUI,
+	# try to find the last compatible version of the plugin.
+	if not SemanticVersion.is_feature_compatible(min_api_version, PluginLoader.PLUGIN_API_VERSION):
+		if not "versions" in plugin or not plugin["versions"] is Array:
+			return
+		for version in plugin["versions"]:
+			if not "plugin.min-api-version" in version:
+				continue
+			min_api_version = plugin["plugin.min-api-version"] as String
+			if not SemanticVersion.is_feature_compatible(min_api_version, PluginLoader.PLUGIN_API_VERSION):
+				continue
+			if not "archive.url" in version:
+				continue
+			if not "archive.sha256" in version:
+				continue
+			download_url = version["archive.url"] as String
+			hash = version["archive.sha256"] as String
+
+	# Build the store item
+	var store_item := plugin_store_card_scene.instantiate()
+	store_item.visible = false
+	store_item.download_url = plugin["archive.url"]
+	store_item.project_url = plugin["plugin.link"]
+	store_item.sha256 = plugin["archive.sha256"]
+	store_item.plugin_id = plugin["plugin.id"]
+	store_item.name = store_item.plugin_id
+	grid.add_child(store_item)
+	store_item.plugin_name_label.text = plugin["plugin.name"]
+	store_item.summary_label.text = plugin["plugin.summary"]
+
+	# Load the plugin image
+	if len(plugin["store.images"]) > 0:
+		var image = await http_image.fetch(plugin["store.images"][0])
+		if image != null:
+			store_item.plugin_texture.texture = image
+	
+	# Add the store item
+	store_item.visible = true
 
 
 func _on_plugin_upgradable(plugin_id: String, update_type: int) -> void:


### PR DESCRIPTION
This change updates the plugin store to use the latest compatible version of a plugin if it is available. This should fix the case where a user using an older version of OpenGamepadUI can still install older versions of a plugin that may be compatible with their running version of OpenGamepadUI.