### PR TITLE
add Steam Deck L/R touchpad support

### DIFF
--- a/core/global/launch_manager.gd
+++ b/core/global/launch_manager.gd
@@ -541,7 +541,7 @@ func set_gamepad_profile(profile_path: String, target_gamepad: String = "") -> v
 		if not target_gamepad.is_empty():
 			var target_devices := PackedStringArray([target_gamepad, "keyboard", "mouse"])
 			match target_gamepad:
-				"xb360", "xbox-series", "xbox-elite", "gamepad", "hori-steam":
+				"xb360", "xbox-series", "xbox-elite", "gamepad", "hori-steam", "deck", "deck-uhid":
 					target_devices.append("touchpad")
 				_:
 					logger.debug(target_gamepad, "needs no additional target devices.")


### PR DESCRIPTION
this allows proper LeftPad and RightPad touchpad definitions for steam deck and enables touchpad for deck and deck-uhid.

this is only the leftpad/rightpad profile support side.

requires https://github.com/ShadowBlip/InputPlumber/pull/493 in inputplumber for steamos l/r pad input mapping

partially fixes #476, needs gui frontend extension.