### PR TITLE
fix: update extension dependencies to allow building with Rust 1.94.x

### DIFF
--- a/extensions/Cargo.lock
+++ b/extensions/Cargo.lock
@@ -3,39 +3,30 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayvec"
@@ -69,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -83,27 +74,27 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.8",
+ "rustix",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -112,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel",
  "async-io",
@@ -125,7 +116,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.8",
+ "rustix",
 ]
 
 [[package]]
@@ -136,14 +127,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
  "async-io",
  "async-lock",
@@ -151,10 +142,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.8",
+ "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -165,13 +156,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -187,25 +178,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -217,15 +193,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -243,40 +210,42 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.7"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-unit"
-version = "5.1.6"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
 dependencies = [
  "rust_decimal",
+ "schemars",
  "serde",
  "utf8-width",
 ]
@@ -305,15 +274,15 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -331,39 +300,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "docgen"
@@ -374,10 +314,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.0"
+name = "dyn-clone"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enumflags2"
@@ -397,7 +343,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -408,12 +354,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -444,6 +390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,15 +403,15 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -476,39 +428,38 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "gamescope-x11-client"
 version = "0.1.0"
-source = "git+https://github.com/ShadowBlip/gamescope-x11-client?branch=main#3cb6fdd564e13c2222606d5fae3abd81e6fe457b"
+source = "git+https://github.com/ShadowBlip/gamescope-x11-client?branch=main#922e02a8c941c278e665639c57a1822abd31bee3"
 dependencies = [
  "log",
  "strum",
@@ -518,70 +469,55 @@ dependencies = [
 
 [[package]]
 name = "gdextension-api"
-version = "0.2.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec0a03c8f9c91e3d8eb7ca56dea81c7248c03826dd3f545f33cd22ef275d4d1"
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
+checksum = "5383f33a2772746bbc83e5b0480862dd1eedfd0518b976f37f3db11c81e71a6a"
 
 [[package]]
 name = "gethostname"
-version = "0.4.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "libc",
- "windows-targets 0.48.5",
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "glam"
-version = "0.30.5"
+version = "0.30.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d1aab06663bdce00d6ca5e5ed586ec8d18033a771906c993a1e3755b368d85"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
 
 [[package]]
 name = "godot"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88bc5c641a412f8098695546790e13d8e1c0b2ec6556356e2c6f47f8d80c91"
+checksum = "5599d03afd17a511e11d0bf9e06c88d4095a9120f10cf00a74f50b300f53413e"
 dependencies = [
  "godot-core",
  "godot-macros",
@@ -589,24 +525,24 @@ dependencies = [
 
 [[package]]
 name = "godot-bindings"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b232ed5a858d55c7d450fd532e46dcfdc5616e7f7a31b77a39abf56acf55837"
+checksum = "f38b6e65306c05e3c3f0131ee8dbf7394691e53268d72019007ec20687f2280f"
 dependencies = [
  "gdextension-api",
 ]
 
 [[package]]
 name = "godot-cell"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c30a71a51456c7a190cfa01ad4c21700bb03df24dd41edb4c632c23e0306407c"
+checksum = "738efef92fdcf1d92f0ed5a29c6f3cdce58e64029d08928c20e08771e1239c16"
 
 [[package]]
 name = "godot-codegen"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5970685601c06be9fc7f53c0560bda1c813d81604b748dbf057e4db22b788e0f"
+checksum = "00b9a59f603f354c54d83fb74071209203d0ebe396b2419acc731c90ebf94680"
 dependencies = [
  "godot-bindings",
  "heck 0.5.0",
@@ -618,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "godot-core"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea7fa55d72449795e32dc3c115efbbe2b6a4fb7fd5336bd8b27985e4731baa59"
+checksum = "989e80dfb58d2048ae0dca60bec32129dc1f96510f904b992ad170d84e950c33"
 dependencies = [
  "glam",
  "godot-bindings",
@@ -631,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "godot-ffi"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed673789ef833491f717074ccd9a5dde987760e56b872f6d63094d52d616a1"
+checksum = "6237b26c52c5baa6566705a73cd8804ea4ef83a666540939dd5a4e068c242666"
 dependencies = [
  "godot-bindings",
  "godot-codegen",
@@ -643,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "godot-macros"
-version = "0.3.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e3396be9600ee93a3457628ad021fe5e6c0940b4ace5067ef92d5f448931cf"
+checksum = "d696b67ba99ff7d75e07546b04c3a711651d2c9e5851c9225dea3b64f8bb5af6"
 dependencies = [
  "godot-bindings",
  "litrs",
@@ -669,6 +605,15 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -695,20 +640,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "indexmap"
-version = "2.10.0"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "inotify"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
  "bitflags",
  "futures-core",
@@ -727,27 +680,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -755,57 +697,54 @@ dependencies = [
 
 [[package]]
 name = "keyvalues-parser"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4c8354918309196302015ac9cae43362f1a13d0d5c5539a33b4c2fd2cd6d25"
+checksum = "3b1d591f0c9482810347586bd2ae842bbd1fc4e0849283c611244930ff44e90f"
 dependencies = [
  "pest",
- "pest_derive",
- "thiserror 1.0.69",
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litrs"
-version = "0.4.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "markdown"
@@ -818,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -832,23 +771,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -880,15 +810,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -901,19 +830,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opengamepadui-core"
@@ -926,7 +846,7 @@ dependencies = [
  "inotify",
  "keyvalues-parser",
  "log",
- "nix 0.30.1",
+ "nix 0.31.2",
  "once_cell",
  "tokio",
  "zbus",
@@ -951,9 +871,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -961,78 +881,38 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror 2.0.14",
  "ucd-trie",
 ]
 
 [[package]]
-name = "pest_derive"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.105",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -1041,16 +921,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1063,19 +943,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.3.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1102,18 +992,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1148,7 +1038,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1160,18 +1050,38 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.2"
+name = "ref-cast"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1181,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1192,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rend"
@@ -1207,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -1225,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1245,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.37.2"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -1260,35 +1170,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1298,10 +1189,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "schemars"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1316,35 +1213,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1355,26 +1269,16 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1386,9 +1290,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1398,19 +1302,13 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
@@ -1428,7 +1326,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1444,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.105"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1461,62 +1359,22 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
-dependencies = [
- "thiserror-impl 2.0.14",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.105",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.105",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1529,57 +1387,67 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "socket2",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "toml_parser",
+ "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+dependencies = [
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1588,29 +1456,23 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -1620,40 +1482,47 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
 name = "unicode-id"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1680,45 +1549,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1726,274 +1591,179 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "leb128fmt",
+ "wasmparser",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "wasm-metadata"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "winnow"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
  "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -2007,26 +1777,26 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix 0.38.44",
+ "rustix",
  "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "zbus"
-version = "5.9.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -2042,14 +1812,16 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.30.1",
+ "libc",
  "ordered-stream",
+ "rustix",
  "serde",
  "serde_repr",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
- "winnow",
+ "uuid",
+ "windows-sys",
+ "winnow 0.7.15",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -2057,14 +1829,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.9.0"
+version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -2072,73 +1844,77 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.2.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "static_assertions",
- "winnow",
+ "winnow 0.7.15",
  "zvariant",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "zvariant"
-version = "5.6.0"
+name = "zmij"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow",
+ "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.6.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.117",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "static_assertions",
- "syn 2.0.105",
- "winnow",
+ "syn 2.0.117",
+ "winnow 0.7.15",
 ]

--- a/extensions/core/Cargo.toml
+++ b/extensions/core/Cargo.toml
@@ -7,18 +7,18 @@ edition = "2021"
 crate-type = ["cdylib"] # Compile this crate to a dynamic C library.
 
 [dependencies]
-futures-util = "0.3.31"
-godot = { version = "0.3.4", features = [
+futures-util = "0.3.32"
+godot = { version = "0.4.5", features = [
   "experimental-threads",
   "register-docs",
 ] }
-nix = { version = "0.30.1", features = ["term", "process", "fs"] }
-once_cell = "1.21.3"
-tokio = { version = "1.47.0", features = ["full"] }
-zbus = "5.9.0"
-zvariant = "5.6.0"
+nix = { version = "0.31.2", features = ["term", "process", "fs"] }
+once_cell = "1.21.4"
+tokio = { version = "1.50.0", features = ["full"] }
+zbus = "5.14.0"
+zvariant = "5.10.0"
 gamescope-x11-client = { git = "https://github.com/ShadowBlip/gamescope-x11-client", branch = "main" }
-inotify = "0.11.0"
-byte-unit = "5.1.6"
-log = "0.4.27"
-keyvalues-parser = "0.2.0"
+inotify = "0.11.1"
+byte-unit = "5.2.0"
+log = "0.4.29"
+keyvalues-parser = "0.2.3"

--- a/extensions/core/src/bluetooth/bluez/adapter.rs
+++ b/extensions/core/src/bluetooth/bluez/adapter.rs
@@ -178,12 +178,12 @@ impl BluetoothAdapter {
                 let device: Gd<BluetoothAdapter> = res.cast();
                 device
             } else {
-                let mut device = BluetoothAdapter::from_path(path.to_string().into());
+                let mut device = BluetoothAdapter::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = BluetoothAdapter::from_path(path.to_string().into());
+            let mut device = BluetoothAdapter::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -200,7 +200,7 @@ impl BluetoothAdapter {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.address().unwrap_or_default().into()
+        proxy.address().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -208,7 +208,7 @@ impl BluetoothAdapter {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.address_type().unwrap_or_default().into()
+        proxy.address_type().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -216,7 +216,7 @@ impl BluetoothAdapter {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.alias().unwrap_or_default().into()
+        proxy.alias().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -304,7 +304,7 @@ impl BluetoothAdapter {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.modalias().unwrap_or_default().into()
+        proxy.modalias().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -312,7 +312,7 @@ impl BluetoothAdapter {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -352,7 +352,7 @@ impl BluetoothAdapter {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.power_state().unwrap_or_default().into()
+        proxy.power_state().unwrap_or_default().as_str().into()
     }
 
     #[func]

--- a/extensions/core/src/bluetooth/bluez/device.rs
+++ b/extensions/core/src/bluetooth/bluez/device.rs
@@ -174,12 +174,12 @@ impl BluetoothDevice {
                 let device: Gd<BluetoothDevice> = res.cast();
                 device
             } else {
-                let mut device = BluetoothDevice::from_path(path.to_string().into());
+                let mut device = BluetoothDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = BluetoothDevice::from_path(path.to_string().into());
+            let mut device = BluetoothDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -324,7 +324,7 @@ impl BluetoothDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -332,7 +332,7 @@ impl BluetoothDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.modalias().unwrap_or_default().into()
+        proxy.modalias().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -348,7 +348,7 @@ impl BluetoothDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.icon().unwrap_or_default().into()
+        proxy.icon().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -404,7 +404,7 @@ impl BluetoothDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.alias().unwrap_or_default().into()
+        proxy.alias().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -422,7 +422,7 @@ impl BluetoothDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.address_type().unwrap_or_default().into()
+        proxy.address_type().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -430,7 +430,7 @@ impl BluetoothDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.address().unwrap_or_default().into()
+        proxy.address().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -438,7 +438,7 @@ impl BluetoothDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.adapter().unwrap_or_default().to_string().into()
+        proxy.adapter().unwrap_or_default().as_str().into()
     }
 
     /// Dispatches signals

--- a/extensions/core/src/dbus.rs
+++ b/extensions/core/src/dbus.rs
@@ -69,7 +69,7 @@ impl<'a> GodotVariant for zvariant::Value<'a> {
                 Some(arr.to_variant())
             }
             zvariant::Value::Dict(value) => {
-                let mut dict = Dictionary::new();
+                let mut dict = VarDictionary::new();
                 for (key, val) in value.iter() {
                     let Some(key) = key.as_godot_variant() else {
                         continue;
@@ -90,12 +90,12 @@ impl<'a> GodotVariant for zvariant::Value<'a> {
 
 /// Interface for converting Godot types -> DBus types
 pub trait DBusVariant {
-    fn as_zvariant(&self) -> Option<zvariant::Value>;
+    fn as_zvariant(&'_ self) -> Option<zvariant::Value<'_>>;
 }
 
 impl DBusVariant for Variant {
     /// Convert the Godot variant type into a DBus variant type
-    fn as_zvariant(&self) -> Option<zvariant::Value> {
+    fn as_zvariant(&'_ self) -> Option<zvariant::Value<'_>> {
         match self.get_type() {
             VariantType::NIL => {
                 let value = zvariant::Optional::<&str>::null_value();

--- a/extensions/core/src/dbus/networkmanager/active.rs
+++ b/extensions/core/src/dbus/networkmanager/active.rs
@@ -25,10 +25,6 @@ use zbus::proxy;
     default_service = "org.freedesktop.NetworkManager"
 )]
 pub trait Active {
-    /// StateChanged signal
-    //#[zbus(signal)]
-    //fn state_changed(&self, state: u32, reason: u32) -> zbus::Result<()>;
-
     /// Connection property
     #[zbus(property)]
     fn connection(&self) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;

--- a/extensions/core/src/dbus/networkmanager/device.rs
+++ b/extensions/core/src/dbus/networkmanager/device.rs
@@ -55,10 +55,6 @@ pub trait Device {
         flags: u32,
     ) -> zbus::Result<()>;
 
-    /// StateChanged signal
-    //#[zbus(signal)]
-    //fn state_changed(&self, new_state: u32, old_state: u32, reason: u32) -> zbus::Result<()>;
-
     /// ActiveConnection property
     #[zbus(property)]
     fn active_connection(&self) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;

--- a/extensions/core/src/dbus/networkmanager/network_manager.rs
+++ b/extensions/core/src/dbus/networkmanager/network_manager.rs
@@ -125,10 +125,6 @@ pub trait NetworkManager {
     /// Sleep method
     fn sleep(&self, sleep: bool) -> zbus::Result<()>;
 
-    /// state method
-    //#[zbus(name = "state")]
-    //fn state(&self) -> zbus::Result<u32>;
-
     /// CheckPermissions signal
     #[zbus(signal)]
     fn check_permissions(&self) -> zbus::Result<()>;
@@ -140,10 +136,6 @@ pub trait NetworkManager {
     /// DeviceRemoved signal
     #[zbus(signal)]
     fn device_removed(&self, device_path: zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
-
-    /// StateChanged signal
-    //#[zbus(signal)]
-    //fn state_changed(&self, state: u32) -> zbus::Result<()>;
 
     /// ActivatingConnection property
     #[zbus(property)]
@@ -192,11 +184,6 @@ pub trait NetworkManager {
     fn global_dns_configuration(
         &self,
     ) -> zbus::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>;
-    //#[zbus(property)]
-    //fn set_global_dns_configuration(
-    //    &self,
-    //    value: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
-    //) -> zbus::Result<()>;
 
     /// Metered property
     #[zbus(property)]

--- a/extensions/core/src/disk/udisks2/block_device.rs
+++ b/extensions/core/src/disk/udisks2/block_device.rs
@@ -91,12 +91,12 @@ impl BlockDevice {
                 let device: Gd<BlockDevice> = res.cast();
                 device
             } else {
-                let mut device = BlockDevice::from_path(path.to_string().into());
+                let mut device = BlockDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = BlockDevice::from_path(path.to_string().into());
+            let mut device = BlockDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }

--- a/extensions/core/src/disk/udisks2/drive_device.rs
+++ b/extensions/core/src/disk/udisks2/drive_device.rs
@@ -79,12 +79,12 @@ impl DriveDevice {
                 let device: Gd<DriveDevice> = res.cast();
                 device
             } else {
-                let mut device = DriveDevice::from_path(path.to_string().into());
+                let mut device = DriveDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = DriveDevice::from_path(path.to_string().into());
+            let mut device = DriveDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }

--- a/extensions/core/src/disk/udisks2/filesystem_device.rs
+++ b/extensions/core/src/disk/udisks2/filesystem_device.rs
@@ -66,12 +66,12 @@ impl FilesystemDevice {
                 let device: Gd<FilesystemDevice> = res.cast();
                 device
             } else {
-                let mut device = FilesystemDevice::from_path(path.to_string().into());
+                let mut device = FilesystemDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = FilesystemDevice::from_path(path.to_string().into());
+            let mut device = FilesystemDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }

--- a/extensions/core/src/disk/udisks2/partition_device.rs
+++ b/extensions/core/src/disk/udisks2/partition_device.rs
@@ -61,7 +61,7 @@ impl PartitionDevice {
         })
     }
     /// Return a proxy instance to the block device dbus interface
-    fn get_block_proxy(&self) -> Option<BlockProxyBlocking> {
+    fn get_block_proxy(&'_ self) -> Option<BlockProxyBlocking<'_>> {
         if let Some(conn) = self.conn.as_ref() {
             let path: String = self.dbus_path.clone().into();
             BlockProxyBlocking::builder(conn)
@@ -74,7 +74,7 @@ impl PartitionDevice {
     }
 
     /// Return a proxy instance to the partition dbus interface
-    fn get_partition_proxy(&self) -> Option<PartitionProxyBlocking> {
+    fn get_partition_proxy(&'_ self) -> Option<PartitionProxyBlocking<'_>> {
         if let Some(conn) = self.conn.as_ref() {
             let path: String = self.dbus_path.clone().into();
             PartitionProxyBlocking::builder(conn)
@@ -87,7 +87,7 @@ impl PartitionDevice {
     }
 
     /// Return a proxy instance to the filesystem dbus interface
-    fn get_filesystem_proxy(&self) -> Option<FilesystemProxyBlocking> {
+    fn get_filesystem_proxy(&'_ self) -> Option<FilesystemProxyBlocking<'_>> {
         if let Some(conn) = self.conn.as_ref() {
             let path: String = self.dbus_path.clone().into();
             FilesystemProxyBlocking::builder(conn)
@@ -113,12 +113,12 @@ impl PartitionDevice {
                 let device: Gd<PartitionDevice> = res.cast();
                 device
             } else {
-                let mut device = PartitionDevice::from_path(path.to_string().into());
+                let mut device = PartitionDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = PartitionDevice::from_path(path.to_string().into());
+            let mut device = PartitionDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }

--- a/extensions/core/src/gamescope/x11_client.rs
+++ b/extensions/core/src/gamescope/x11_client.rs
@@ -242,12 +242,12 @@ impl GamescopeXWayland {
                 let device: Gd<GamescopeXWayland> = res.cast();
                 device
             } else {
-                let mut device = GamescopeXWayland::from_name(name.to_string().into());
+                let mut device = GamescopeXWayland::from_name(name.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = GamescopeXWayland::from_name(name.to_string().into());
+            let mut device = GamescopeXWayland::from_name(name.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -403,7 +403,7 @@ impl GamescopeXWayland {
             }
         };
 
-        name.unwrap_or_default().into()
+        name.unwrap_or_default().as_str().into()
     }
 
     /// Returns the window x and y position for the given window. Returns (-1, -1)
@@ -668,7 +668,10 @@ impl GamescopeXWayland {
                 return Default::default();
             }
         };
-        let value: Vec<GString> = value.into_iter().map(GString::from).collect();
+        let value: Vec<GString> = value
+            .into_iter()
+            .map(|v| GString::from(v.as_str()))
+            .collect();
         self.focusable_window_names = value.into();
         self.focusable_window_names.clone()
     }
@@ -1214,7 +1217,7 @@ impl GamescopeXWayland {
 #[godot_api]
 impl IResource for GamescopeXWayland {
     fn to_string(&self) -> GString {
-        format!("<GamescopeXWayland#{}>", self.name).into()
+        format!("<GamescopeXWayland#{}>", self.name).as_str().into()
     }
 }
 

--- a/extensions/core/src/input/inputplumber.rs
+++ b/extensions/core/src/input/inputplumber.rs
@@ -416,7 +416,7 @@ impl InputPlumberInstance {
                 self.composite_devices.remove(&path);
                 self.base_mut().emit_signal(
                     "composite_device_removed",
-                    &[GString::from(path).to_variant()],
+                    &[GString::from(path.as_str()).to_variant()],
                 );
             }
             ObjectType::SourceEventDevice => (),

--- a/extensions/core/src/input/inputplumber/composite_device.rs
+++ b/extensions/core/src/input/inputplumber/composite_device.rs
@@ -104,12 +104,12 @@ impl CompositeDevice {
                 let device: Gd<CompositeDevice> = res.cast();
                 device
             } else {
-                let mut device = CompositeDevice::from_path(path.to_string().into());
+                let mut device = CompositeDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = CompositeDevice::from_path(path.to_string().into());
+            let mut device = CompositeDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -121,7 +121,7 @@ impl CompositeDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return "".into();
         };
-        proxy.name().ok().unwrap_or_default().into()
+        proxy.name().ok().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -129,7 +129,12 @@ impl CompositeDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return "".into();
         };
-        proxy.profile_name().ok().unwrap_or_default().into()
+        proxy
+            .profile_name()
+            .ok()
+            .unwrap_or_default()
+            .as_str()
+            .into()
     }
 
     /// Get the intercept mode of the composite device
@@ -162,7 +167,7 @@ impl CompositeDevice {
             .ok()
             .unwrap_or_default()
             .into_iter()
-            .map(GString::from)
+            .map(|v| GString::from(v.as_str()))
             .collect();
         PackedStringArray::from(caps.as_slice())
     }
@@ -178,7 +183,7 @@ impl CompositeDevice {
             .ok()
             .unwrap_or_default()
             .into_iter()
-            .map(GString::from)
+            .map(|v| GString::from(v.as_str()))
             .collect();
         PackedStringArray::from(caps.as_slice())
     }
@@ -205,7 +210,7 @@ impl CompositeDevice {
             .ok()
             .unwrap_or_default()
             .into_iter()
-            .map(GString::from)
+            .map(|v| GString::from(v.as_str()))
             .collect();
         PackedStringArray::from(values.as_slice())
     }
@@ -221,7 +226,7 @@ impl CompositeDevice {
             .ok()
             .unwrap_or_default()
             .into_iter()
-            .map(GString::from)
+            .map(|v| GString::from(v.as_str()))
             .collect();
         PackedStringArray::from(values.as_slice())
     }
@@ -276,7 +281,7 @@ impl CompositeDevice {
     /// Returns the DBus path to the [CompositeDevice]
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Load the device profile from the given path

--- a/extensions/core/src/input/inputplumber/dbus_device.rs
+++ b/extensions/core/src/input/inputplumber/dbus_device.rs
@@ -93,12 +93,12 @@ impl DBusDevice {
                 let device: Gd<DBusDevice> = res.cast();
                 device
             } else {
-                let mut device = DBusDevice::from_path(path.to_string().into());
+                let mut device = DBusDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = DBusDevice::from_path(path.to_string().into());
+            let mut device = DBusDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -106,7 +106,7 @@ impl DBusDevice {
 
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Dispatches signals

--- a/extensions/core/src/input/inputplumber/event_device.rs
+++ b/extensions/core/src/input/inputplumber/event_device.rs
@@ -78,12 +78,12 @@ impl EventDevice {
                 let device: Gd<EventDevice> = res.cast();
                 device
             } else {
-                let mut device = EventDevice::from_path(path.to_string().into());
+                let mut device = EventDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = EventDevice::from_path(path.to_string().into());
+            let mut device = EventDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -91,7 +91,7 @@ impl EventDevice {
 
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Get the name of the [EventDevice]
@@ -100,7 +100,7 @@ impl EventDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return "".into();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -108,7 +108,7 @@ impl EventDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return "".into();
         };
-        proxy.device_path().unwrap_or_default().into()
+        proxy.device_path().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -116,7 +116,7 @@ impl EventDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return "".into();
         };
-        proxy.phys_path().unwrap_or_default().into()
+        proxy.phys_path().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -124,7 +124,7 @@ impl EventDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return "".into();
         };
-        proxy.sysfs_path().unwrap_or_default().into()
+        proxy.sysfs_path().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -132,6 +132,6 @@ impl EventDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return "".into();
         };
-        proxy.unique_id().unwrap_or_default().into()
+        proxy.unique_id().unwrap_or_default().as_str().into()
     }
 }

--- a/extensions/core/src/input/inputplumber/gamepad_device.rs
+++ b/extensions/core/src/input/inputplumber/gamepad_device.rs
@@ -83,12 +83,12 @@ impl GamepadDevice {
                 let device: Gd<GamepadDevice> = res.cast();
                 device
             } else {
-                let mut device = GamepadDevice::from_path(path.to_string().into());
+                let mut device = GamepadDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = GamepadDevice::from_path(path.to_string().into());
+            let mut device = GamepadDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -96,7 +96,7 @@ impl GamepadDevice {
 
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Get the name of the [GamepadDevice]
@@ -105,7 +105,7 @@ impl GamepadDevice {
         let Some(proxy) = self.gamepad_proxy.as_ref() else {
             return "".into();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     /// Get the type of the [GamepadDevice]
@@ -114,6 +114,6 @@ impl GamepadDevice {
         let Some(proxy) = self.target_proxy.as_ref() else {
             return "".into();
         };
-        proxy.device_type().unwrap_or_default().into()
+        proxy.device_type().unwrap_or_default().as_str().into()
     }
 }

--- a/extensions/core/src/input/inputplumber/keyboard_device.rs
+++ b/extensions/core/src/input/inputplumber/keyboard_device.rs
@@ -83,12 +83,12 @@ impl KeyboardDevice {
                 let device: Gd<KeyboardDevice> = res.cast();
                 device
             } else {
-                let mut device = KeyboardDevice::from_path(path.to_string().into());
+                let mut device = KeyboardDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = KeyboardDevice::from_path(path.to_string().into());
+            let mut device = KeyboardDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -96,7 +96,7 @@ impl KeyboardDevice {
 
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Get the name of the [KeyboardDevice]
@@ -105,7 +105,7 @@ impl KeyboardDevice {
         let Some(proxy) = self.keyboard_proxy.as_ref() else {
             return "".into();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -123,6 +123,6 @@ impl KeyboardDevice {
         let Some(proxy) = self.target_proxy.as_ref() else {
             return "".into();
         };
-        proxy.device_type().unwrap_or_default().into()
+        proxy.device_type().unwrap_or_default().as_str().into()
     }
 }

--- a/extensions/core/src/input/inputplumber/mouse_device.rs
+++ b/extensions/core/src/input/inputplumber/mouse_device.rs
@@ -82,12 +82,12 @@ impl MouseDevice {
                 let device: Gd<MouseDevice> = res.cast();
                 device
             } else {
-                let mut device = MouseDevice::from_path(path.to_string().into());
+                let mut device = MouseDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = MouseDevice::from_path(path.to_string().into());
+            let mut device = MouseDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -95,7 +95,7 @@ impl MouseDevice {
 
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Get the name of the [MouseDevice]
@@ -104,7 +104,7 @@ impl MouseDevice {
         let Some(proxy) = self.mouse_proxy.as_ref() else {
             return "".into();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -121,6 +121,6 @@ impl MouseDevice {
         let Some(proxy) = self.target_proxy.as_ref() else {
             return "".into();
         };
-        proxy.device_type().unwrap_or_default().into()
+        proxy.device_type().unwrap_or_default().as_str().into()
     }
 }

--- a/extensions/core/src/network/network_manager/access_point.rs
+++ b/extensions/core/src/network/network_manager/access_point.rs
@@ -211,12 +211,12 @@ impl NetworkAccessPoint {
                 let device: Gd<NetworkAccessPoint> = res.cast();
                 device
             } else {
-                let mut device = NetworkAccessPoint::from_path(path.to_string().into());
+                let mut device = NetworkAccessPoint::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = NetworkAccessPoint::from_path(path.to_string().into());
+            let mut device = NetworkAccessPoint::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -323,7 +323,10 @@ impl NetworkAccessPoint {
             return Default::default();
         };
         let value = proxy.ssid().unwrap_or_default();
-        String::from_utf8_lossy(value.as_slice()).to_string().into()
+        String::from_utf8_lossy(value.as_slice())
+            .to_string()
+            .as_str()
+            .into()
     }
 
     /// The current signal quality of the access point, in percent.
@@ -368,7 +371,7 @@ impl NetworkAccessPoint {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.hw_address().unwrap_or_default().into()
+        proxy.hw_address().unwrap_or_default().as_str().into()
     }
 
     /// Describes the operating mode of the access point.

--- a/extensions/core/src/network/network_manager/active_connection.rs
+++ b/extensions/core/src/network/network_manager/active_connection.rs
@@ -115,12 +115,12 @@ impl NetworkActiveConnection {
                 let device: Gd<NetworkActiveConnection> = res.cast();
                 device
             } else {
-                let mut device = NetworkActiveConnection::from_path(path.to_string().into());
+                let mut device = NetworkActiveConnection::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = NetworkActiveConnection::from_path(path.to_string().into());
+            let mut device = NetworkActiveConnection::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }

--- a/extensions/core/src/network/network_manager/device.rs
+++ b/extensions/core/src/network/network_manager/device.rs
@@ -219,12 +219,12 @@ impl NetworkDevice {
                 let device: Gd<NetworkDevice> = res.cast();
                 device
             } else {
-                let mut device = NetworkDevice::from_path(path.to_string().into());
+                let mut device = NetworkDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = NetworkDevice::from_path(path.to_string().into());
+            let mut device = NetworkDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -264,7 +264,7 @@ impl NetworkDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.interface().unwrap_or_default().into()
+        proxy.interface().unwrap_or_default().as_str().into()
     }
 
     /// The [NetworkIpv4Config] describing the configuration of the device. Null if device has no IP.

--- a/extensions/core/src/network/network_manager/device_wireless.rs
+++ b/extensions/core/src/network/network_manager/device_wireless.rs
@@ -114,12 +114,12 @@ impl NetworkDeviceWireless {
                 let device: Gd<NetworkDeviceWireless> = res.cast();
                 device
             } else {
-                let mut device = NetworkDeviceWireless::from_path(path.to_string().into());
+                let mut device = NetworkDeviceWireless::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = NetworkDeviceWireless::from_path(path.to_string().into());
+            let mut device = NetworkDeviceWireless::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -200,7 +200,7 @@ impl NetworkDeviceWireless {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.hw_address().unwrap_or_default().into()
+        proxy.hw_address().unwrap_or_default().as_str().into()
     }
 
     /// Process signals and emit them as Godot signals.

--- a/extensions/core/src/network/network_manager/ip4_config.rs
+++ b/extensions/core/src/network/network_manager/ip4_config.rs
@@ -21,7 +21,7 @@ pub struct NetworkIpv4Config {
     /// Array of IP address data objects. All addresses will include "address" (an IP address string), and "prefix" (a uint). Some addresses may include additional attributes.
     #[allow(dead_code)]
     #[var(get = get_addresses)]
-    addresses: Array<Dictionary>,
+    addresses: Array<VarDictionary>,
     /// The gateway in use.
     #[allow(dead_code)]
     #[var(get = get_gateway)]
@@ -72,12 +72,12 @@ impl NetworkIpv4Config {
                 let device: Gd<NetworkIpv4Config> = res.cast();
                 device
             } else {
-                let mut device = NetworkIpv4Config::from_path(path.to_string().into());
+                let mut device = NetworkIpv4Config::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = NetworkIpv4Config::from_path(path.to_string().into());
+            let mut device = NetworkIpv4Config::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -100,14 +100,14 @@ impl NetworkIpv4Config {
 
     /// Array of IP address data objects. All addresses will include "address" (an IP address string), and "prefix" (a uint). Some addresses may include additional attributes.
     #[func]
-    pub fn get_addresses(&self) -> Array<Dictionary> {
+    pub fn get_addresses(&self) -> Array<VarDictionary> {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
         let mut value = array![];
         let data = proxy.address_data().unwrap_or_default();
         for entry in data {
-            let mut dict = Dictionary::new();
+            let mut dict = VarDictionary::new();
             for (key, value) in entry.iter() {
                 let Some(value) = value.as_godot_variant() else {
                     continue;

--- a/extensions/core/src/performance/powerstation/cpu.rs
+++ b/extensions/core/src/performance/powerstation/cpu.rs
@@ -119,12 +119,12 @@ impl Cpu {
                 let device: Gd<Cpu> = res.cast();
                 device
             } else {
-                let mut device = Cpu::from_path(path.to_string().into());
+                let mut device = Cpu::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = Cpu::from_path(path.to_string().into());
+            let mut device = Cpu::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -133,7 +133,7 @@ impl Cpu {
     /// Return the DBus path to the CPU instance
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Return all the CPU cores for the CPU

--- a/extensions/core/src/performance/powerstation/cpu_core.rs
+++ b/extensions/core/src/performance/powerstation/cpu_core.rs
@@ -92,12 +92,12 @@ impl CpuCore {
                 let device: Gd<CpuCore> = res.cast();
                 device
             } else {
-                let mut device = CpuCore::from_path(path.to_string().into());
+                let mut device = CpuCore::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = CpuCore::from_path(path.to_string().into());
+            let mut device = CpuCore::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -106,7 +106,7 @@ impl CpuCore {
     /// Return the DBus path to the CPU Core instance
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     /// Return the core id of the CPU core

--- a/extensions/core/src/performance/powerstation/gpu.rs
+++ b/extensions/core/src/performance/powerstation/gpu.rs
@@ -72,12 +72,12 @@ impl Gpu {
                 let device: Gd<Gpu> = res.cast();
                 device
             } else {
-                let mut device = Gpu::from_path(path.to_string().into());
+                let mut device = Gpu::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = Gpu::from_path(path.to_string().into());
+            let mut device = Gpu::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -86,7 +86,7 @@ impl Gpu {
     /// Return the DBus path to the CPU instance
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.path.clone().into()
+        self.path.as_str().into()
     }
 
     #[func]

--- a/extensions/core/src/performance/powerstation/gpu_card.rs
+++ b/extensions/core/src/performance/powerstation/gpu_card.rs
@@ -225,12 +225,12 @@ impl GpuCard {
                 let device: Gd<GpuCard> = res.cast();
                 device
             } else {
-                let mut device = GpuCard::from_path(path.to_string().into());
+                let mut device = GpuCard::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = GpuCard::from_path(path.to_string().into());
+            let mut device = GpuCard::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -239,7 +239,7 @@ impl GpuCard {
     /// Return the DBus path to the GPU connector instance
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.dbus_path.clone().into()
+        self.dbus_path.as_str().into()
     }
 
     /// Returns true if the card supports tdp
@@ -270,7 +270,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -278,7 +278,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.path().unwrap_or_default().into()
+        proxy.path().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -318,7 +318,7 @@ impl GpuCard {
         let Some(proxy) = self.tdp_proxy.as_ref() else {
             return Default::default();
         };
-        proxy.power_profile().unwrap_or_default().into()
+        proxy.power_profile().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -399,7 +399,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.device_id().unwrap_or_default().into()
+        proxy.device_id().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -407,7 +407,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.subdevice_id().unwrap_or_default().into()
+        proxy.subdevice_id().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -415,7 +415,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.subvendor_id().unwrap_or_default().into()
+        proxy.subvendor_id().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -423,7 +423,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.vendor().unwrap_or_default().into()
+        proxy.vendor().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -431,7 +431,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.vendor_id().unwrap_or_default().into()
+        proxy.vendor_id().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -455,7 +455,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.subdevice().unwrap_or_default().into()
+        proxy.subdevice().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -463,7 +463,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.revision_id().unwrap_or_default().into()
+        proxy.revision_id().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -471,7 +471,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.device().unwrap_or_default().into()
+        proxy.device().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -495,7 +495,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.class_id().unwrap_or_default().into()
+        proxy.class_id().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -503,7 +503,7 @@ impl GpuCard {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.class().unwrap_or_default().into()
+        proxy.class().unwrap_or_default().as_str().into()
     }
 
     /// Dispatches signals

--- a/extensions/core/src/performance/powerstation/gpu_connector.rs
+++ b/extensions/core/src/performance/powerstation/gpu_connector.rs
@@ -108,12 +108,12 @@ impl GpuConnector {
                 let device: Gd<GpuConnector> = res.cast();
                 device
             } else {
-                let mut device = GpuConnector::from_path(path.to_string().into());
+                let mut device = GpuConnector::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = GpuConnector::from_path(path.to_string().into());
+            let mut device = GpuConnector::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -122,7 +122,7 @@ impl GpuConnector {
     /// Return the DBus path to the GPU connector instance
     #[func]
     pub fn get_dbus_path(&self) -> GString {
-        self.dbus_path.clone().into()
+        self.dbus_path.as_str().into()
     }
 
     #[func]
@@ -164,7 +164,7 @@ impl GpuConnector {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.name().unwrap_or_default().into()
+        proxy.name().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -172,7 +172,7 @@ impl GpuConnector {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.path().unwrap_or_default().into()
+        proxy.path().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -180,7 +180,7 @@ impl GpuConnector {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.status().unwrap_or_default().into()
+        proxy.status().unwrap_or_default().as_str().into()
     }
 
     /// Dispatches signals

--- a/extensions/core/src/power/device.rs
+++ b/extensions/core/src/power/device.rs
@@ -319,12 +319,12 @@ impl UPowerDevice {
                 let device: Gd<UPowerDevice> = res.cast();
                 device
             } else {
-                let mut device = UPowerDevice::from_path(path.to_string().into());
+                let mut device = UPowerDevice::from_path(path.into());
                 device.take_over_path(res_path.as_str());
                 device
             }
         } else {
-            let mut device = UPowerDevice::from_path(path.to_string().into());
+            let mut device = UPowerDevice::from_path(path.into());
             device.take_over_path(res_path.as_str());
             device
         }
@@ -407,7 +407,7 @@ impl UPowerDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.icon_name().ok().unwrap_or_default().into()
+        proxy.icon_name().ok().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -439,7 +439,7 @@ impl UPowerDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.model().ok().unwrap_or_default().into()
+        proxy.model().ok().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -447,7 +447,7 @@ impl UPowerDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.native_path().ok().unwrap_or_default().into()
+        proxy.native_path().ok().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -479,7 +479,7 @@ impl UPowerDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.serial().ok().unwrap_or_default().into()
+        proxy.serial().ok().unwrap_or_default().as_str().into()
     }
 
     #[func]
@@ -543,7 +543,7 @@ impl UPowerDevice {
         let Some(proxy) = self.proxy.as_ref() else {
             return Default::default();
         };
-        proxy.vendor().ok().unwrap_or_default().into()
+        proxy.vendor().ok().unwrap_or_default().as_str().into()
     }
 
     #[func]

--- a/extensions/core/src/vdf.rs
+++ b/extensions/core/src/vdf.rs
@@ -5,18 +5,18 @@ use keyvalues_parser::{Obj, Value, Vdf as VdfParser};
 
 /// Helper class for creating and parsing VDF data.
 ///
-/// The [Vdf] class enables the [Dictionary] data type to be converted to and from a VDF string. This is useful for (de)serializing data that use Valve's data format.
+/// The [Vdf] class enables the [VarDictionary] data type to be converted to and from a VDF string. This is useful for (de)serializing data that use Valve's data format.
 ///
-/// [method stringify] is used to convert a [Dictionary] into a VDF string.
+/// [method stringify] is used to convert a [VarDictionary] into a VDF string.
 ///
-/// [method parse] is used to convert any existing VDF data into a [Dictionary] that can be used within Godot.
+/// [method parse] is used to convert any existing VDF data into a [VarDictionary] that can be used within Godot.
 #[derive(GodotClass)]
 #[class(init, base=RefCounted)]
 pub struct Vdf {
     base: Base<RefCounted>,
-    /// Contains the parsed VDF data in [Dictionary] form.
+    /// Contains the parsed VDF data in [VarDictionary] form.
     #[var]
-    data: Dictionary,
+    data: VarDictionary,
     error_msg: Option<String>,
 }
 
@@ -28,13 +28,13 @@ impl Vdf {
         let Some(msg) = self.error_msg.clone() else {
             return GString::new();
         };
-        msg.into()
+        msg.as_str().into()
     }
 
     /// Converts a dictionary to VDF text and returns the result.
-    /// The VDF format only allows a single top-level key, so others will be ignored if the given [Dictionary] contains more than one top-level key.
+    /// The VDF format only allows a single top-level key, so others will be ignored if the given [VarDictionary] contains more than one top-level key.
     #[func]
-    pub fn stringify(data: Dictionary) -> GString {
+    pub fn stringify(data: VarDictionary) -> GString {
         // Get the first entry in the dictionary. Other top-level entries are ignored.
         let Some((key, value)) = data.iter_shared().next() else {
             return GString::new();
@@ -53,7 +53,7 @@ impl Vdf {
 
         let vdf = VdfParser::new(key, value);
 
-        vdf.to_string().into()
+        vdf.to_string().as_str().into()
     }
 
     /// Attempts to parse the `vdf_text` provided.
@@ -71,7 +71,7 @@ impl Vdf {
             }
         };
 
-        // Convert the vdf data into a Godot Dictionary
+        // Convert the vdf data into a Godot VarDictionary
         let mut dict = vdict! {};
         let key = vdf.key.to_string();
         let value = match vdf.value {
@@ -86,9 +86,9 @@ impl Vdf {
     }
 
     /// Attempts to parse the `vdf_string` provided and returns the parsed data.
-    /// Returns an empty [Dictionary] if parse failed.
+    /// Returns an empty [VarDictionary] if parse failed.
     #[func]
-    pub fn parse_string(vdf_string: GString) -> Dictionary {
+    pub fn parse_string(vdf_string: GString) -> VarDictionary {
         let mut dict = vdict! {};
         let data = vdf_string.to_string();
 
@@ -100,7 +100,7 @@ impl Vdf {
             }
         };
 
-        // Convert the vdf data into a Godot Dictionary
+        // Convert the vdf data into a Godot VarDictionary
         let key = vdf.key.to_string();
         let value = match vdf.value {
             Value::Str(value) => value.to_string().to_variant(),
@@ -111,8 +111,8 @@ impl Vdf {
         dict
     }
 
-    /// Convert the given VDF object into a Godot Dictionary
-    fn obj_to_dict(obj: Obj) -> Dictionary {
+    /// Convert the given VDF object into a Godot VarDictionary
+    fn obj_to_dict(obj: Obj) -> VarDictionary {
         let mut dict = vdict! {};
 
         for vdf in obj.into_vdfs() {
@@ -128,8 +128,8 @@ impl Vdf {
         dict
     }
 
-    /// Convert the given Godot Dictionary into a VDF object
-    fn dict_to_obj<'a>(dict: &'a Dictionary, obj: &'a mut Obj) {
+    /// Convert the given Godot VarDictionary into a VDF object
+    fn dict_to_obj<'a>(dict: &'a VarDictionary, obj: &'a mut Obj) {
         for (key, value) in dict.iter_shared() {
             // Convert the key and value variants into VDF keys and values
             let Some(key) = key.as_vdf() else {
@@ -149,7 +149,7 @@ impl Vdf {
     }
 
     /// Convert the given array into a VDF-friendly dictionary
-    fn array_to_dict(value: &Array<Variant>) -> Dictionary {
+    fn array_to_dict(value: &Array<Variant>) -> VarDictionary {
         let mut dict = vdict! {};
         for (i, value) in value.iter_shared().enumerate() {
             dict.set(i.to_string(), value);
@@ -183,11 +183,11 @@ impl Vdf {
 
 /// Trait for converting Godot variant values into Vdf values
 pub trait VdfVariant {
-    fn as_vdf(&self) -> Option<Value>;
+    fn as_vdf(&'_ self) -> Option<Value<'_>>;
 }
 
 impl VdfVariant for Variant {
-    fn as_vdf(&self) -> Option<Value> {
+    fn as_vdf(&'_ self) -> Option<Value<'_>> {
         match self.get_type() {
             VariantType::NIL => None,
             VariantType::BOOL => {
@@ -234,7 +234,7 @@ impl VdfVariant for Variant {
             VariantType::CALLABLE => None,
             VariantType::SIGNAL => None,
             VariantType::DICTIONARY => {
-                let value: Dictionary = self.to();
+                let value: VarDictionary = self.to();
                 let mut obj = Obj::new();
                 Vdf::dict_to_obj(&value, &mut obj);
                 Some(Value::Obj(obj))


### PR DESCRIPTION
This change updates all rust dependencies for the engine extensions to enable compatibility with Rust 1.94.x. Due to API changes to godot-rust, some minor changes needed to be made to accommodate the breaking changes.