### PR TITLE
fix: use path.get_base_dir() instead of manual split + join

### DIFF
--- a/core/systems/input/input_plumber_profile.gd
+++ b/core/systems/input/input_plumber_profile.gd
@@ -159,9 +159,7 @@ static func get_target_device(target_device_str: String) -> TargetDevice:
 func save(path: String) -> Error:
 	if path.begins_with("user://") or path.begins_with("res://"):
 		path = ProjectSettings.globalize_path(path)
-	var path_parts := Array(path.split("/", false))
-	path_parts.pop_back()
-	var base_path := "/".join(path_parts)
+	var base_path := path.get_base_dir()
 	
 	if DirAccess.make_dir_recursive_absolute(base_path) != OK:
 		print("Failed to mkdir")


### PR DESCRIPTION
This fixes an issue with the profile path resolution in the `save` function that causes InputPlumber profiles to be saved at the wrong path.

The way the path resolution works right now is as follows: `user://` or `res://` paths are globalized, the result is split into an array by `"/"`, the last value is popped off, then the remaining parts are joined using `"/"`. The problem is that this strips off the leading `/`, which turns the result into a relative path. On some setups (especially immutable distros where the path is not writable), this causes errors at runtime when OpenGamepadUI tries to save the profiles:


```
Jun 15 01:07:07 bazzite gamescope-session-plus[174434]: ERROR: Could not create directory: '/usr/share/opengamepadui/home/kun'.
Jun 15 01:07:07 bazzite gamescope-session-plus[174434]:    at: make_dir_recursive (core/io/dir_access.cpp:178)
Jun 15 01:07:07 bazzite gamescope-session-plus[174434]: Failed to mkdir
Jun 15 01:07:07 bazzite gamescope-session-plus[174434]: ERROR: 1554 [ERROR] [InputPlumber] :0: Failed to save OpenGamepadUI Default (Overlay) to user://data/gamepad/profiles/global_default_overlay_xbox-elite.json
Jun 15 01:07:07 bazzite gamescope-session-plus[174434]:    at: push_error (core/variant/variant_utility.cpp:1024)
Jun 15 01:07:07 bazzite gamescope-session-plus[174434]: 1554 [ERROR] [InputPlumber] :0: Failed to save OpenGamepadUI Default (Overlay) to user://data/gamepad/profiles/global_default_overlay_xbox-elite.json
```

This PR fixes the issue by using the built-in `path.get_base_dir` to resolve the base path.

A side effect of this PR is that gamepad profiles may need to be regenerated, since they would be placed at a different path.