### PR TITLE
Disable `window/energy_saving/keep_screen_on` in ProjectSettings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -46,6 +46,7 @@ window/size/mode=2
 window/size/borderless=true
 window/size/always_on_top=true
 window/size/transparent=true
+window/energy_saving/keep_screen_on=false
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 window/per_pixel_transparency/allowed=true


### PR DESCRIPTION
Prevents OpenGamepadUI from inhibiting sleep.

Currently, Godot inhibits system sleep by default, unless `keep_screen_on` is disabled in ProjectSettings. This has many consequences, especially for handheld usage where battery saving is a priority. The bigger consequence caused by this is that when a service like [Bazzite Deck Sleep Inhibitor](https://github.com/addmix/Bazzite-Deck-Sleep-Inhibitor) is used, OGUI will inhibit sleep at all times until the OGUI process is killed. This also means that when OGUI attempts to suspend the system [with this line of code](https://github.com/ShadowBlip/OpenGamepadUI/blob/b149644f46b71e175a2ad223e84c18361596691e/core/systems/power/power_saver.gd#L87), the suspend request will be denied, an error generated, and the suspend timer will not be restarted.