### PR TITLE
fix: Correct loss of focus issue in overlay mode

### DIFF
--- a/core/systems/launcher/reaper.gd
+++ b/core/systems/launcher/reaper.gd
@@ -117,6 +117,13 @@ static func get_parent_pid(pid: int) -> int:
 static func get_pid_group(pid: int) -> int:
 	return get_pid_property_int(pid, "NSpgid")
 
+## Returns whether the given PID exists and has not exited yet.
+static func is_pid_running(pid: int) -> bool:
+	var status := get_pid_status(pid)
+	if status.is_empty():
+		return false
+	var state := status.get("State", "") as String
+	return not state.begins_with("Z") and not state.begins_with("X")
 
 # Returns the PID state the given PID is in
 static func get_pid_state(pid: int) -> String:

--- a/core/systems/launcher/running_app.gd
+++ b/core/systems/launcher/running_app.gd
@@ -207,7 +207,9 @@ func discover_app_type(all_windows: PackedInt64Array, app_pids: PackedInt64Array
 func update_wayland_app(app_pids: PackedInt64Array) -> void:
 	# Check if the app, or any of its children, are still running
 	var running := is_running()
-	if not running:
+	if running:
+		self.not_running_count = 0
+	else:
 		self.not_running_count += 1
 
 	# Update the running app's state
@@ -252,7 +254,9 @@ func update_xwayland_app(all_windows: PackedInt64Array, app_pids: PackedInt64Arr
 
 	# Check if the app, or any of its children, are still running
 	var running := is_running()
-	if not running:
+	if running:
+		not_running_count = 0
+	else:
 		not_running_count += 1
 
 	# Update the running app's state
@@ -381,7 +385,9 @@ func get_all_window_ids(all_windows: PackedInt64Array, app_pids: PackedInt64Arra
 ## Returns true if the app's PID is running or any decendents with the same
 ## process group.
 func is_running() -> bool:
-	return OS.is_process_running(pid)
+	if is_ogui_managed:
+		return OS.is_process_running(pid)
+	return Reaper.is_pid_running(pid)
 
 
 ## Return true if the currently running app is focused


### PR DESCRIPTION
In testing, OS.is_process_running(pid) fails to return the proper value for applications that weren't launched by OpengamepadUI. This PR works around it by using an alternative path for those applications.

With this, and the bazzite_fixes branch, there is a single remaining focus issue if the Steam QAM is open and OGUI is invoked.