### PR TITLE
fix: Respect user-set controller at boot, use deck-uhid and disable per-game profiles when Steam is the underlay

### DIFF
--- a/core/global/launch_manager.gd
+++ b/core/global/launch_manager.gd
@@ -488,20 +488,20 @@ func set_gamepad_profile(profile_path: String, target_gamepad: String = "") -> v
 	# Discover the currently set target for each gamepad to properly add additional
 	# capabilities based on that target
 	for device: CompositeDevice in input_plumber.get_composite_devices():
-		if target_gamepad.is_empty():
-			# First, find the currently set gamepad on the composite device
+		var device_target := target_gamepad
+		if device_target.is_empty():
+			# First, use the target gamepad the user configured, so their
+			# selection survives a restart.
+			device_target = settings_manager.get_value("input", "gamepad_profile_target", "") as String
+		if device_target.is_empty():
+			# Otherwise fall back to the gamepad currently set on the composite device
 			var targets = device.get_target_devices()
 			for target in targets:
 				var target_dbus_path: String = target.get("dbus_path")
 				if not target_dbus_path.contains("target/gamepad"):
 					continue
-				target_gamepad = target.get("device_type")
+				device_target = target.get("device_type")
 				break
-			if not target_gamepad.is_empty():
-				break
-			# Then, if overriden by settings, use that instead
-			#TODO: This is a global setting, refactor settings to permit individual gamepads to have different targets
-			target_gamepad = settings_manager.get_value("input", "gamepad_profile_target", target_gamepad) as String
 
 		# If no profile was specified, unset the gamepad profiles
 		if profile_path == "":
@@ -525,16 +525,16 @@ func set_gamepad_profile(profile_path: String, target_gamepad: String = "") -> v
 				logger.warn("Failed to load gamepad profile: " + profile_path)
 				return
 
-		InputPlumber.load_target_modified_profile(device, profile_path, target_gamepad)
+		InputPlumber.load_target_modified_profile(device, profile_path, device_target)
 
 		# Set the target gamepad if one was specified
-		if not target_gamepad.is_empty():
-			var target_devices := PackedStringArray([target_gamepad, "keyboard", "mouse"])
-			match target_gamepad:
+		if not device_target.is_empty():
+			var target_devices := PackedStringArray([device_target, "keyboard", "mouse"])
+			match device_target:
 				"xb360", "xbox-series", "xbox-elite", "gamepad", "hori-steam":
 					target_devices.append("touchpad")
 				_:
-					logger.debug(target_gamepad, "needs no additional target devices.")
+					logger.debug(device_target, "needs no additional target devices.")
 			logger.info("Setting target devices to: ", target_devices)
 			device.set_target_devices(target_devices)
 

--- a/core/global/launch_manager.gd
+++ b/core/global/launch_manager.gd
@@ -493,6 +493,10 @@ func set_gamepad_profile(profile_path: String, target_gamepad: String = "") -> v
 			# First, use the target gamepad the user configured, so their
 			# selection survives a restart.
 			device_target = settings_manager.get_value("input", "gamepad_profile_target", "") as String
+		if device_target.is_empty() and is_instance_valid(_input_manager):
+			# Next, use the default for the current mode.
+			# Overlay mode emulates a Steam Deck controller
+			device_target = _input_manager.get_default_target_gamepad()
 		if device_target.is_empty():
 			# Otherwise fall back to the gamepad currently set on the composite device
 			var targets = device.get_target_devices()

--- a/core/global/launch_manager.gd
+++ b/core/global/launch_manager.gd
@@ -64,6 +64,8 @@ var _persist_path: String = "/".join([_data_dir, "launcher.json"])
 var _persist_data: Dictionary = {"version": 1}
 var _ogui_window_id := 0
 var should_manage_overlay := true
+## Whether Steam is the process OpenGamepadUI is running on top of in overlay
+var steam_is_underlay := false
 var logger := Log.get_logger("LaunchManager", Log.LEVEL.INFO)
 var _focused_app_id := 0
 var _input_manager: InputManager
@@ -476,6 +478,11 @@ func set_app_gamepad_profile(app: RunningApp) -> void:
 	var section := ".".join(["game", app.launch_item.name.to_lower()])
 	var profile_path := settings_manager.get_value(section, "gamepad_profile", "") as String
 	var profile_gamepad := settings_manager.get_value(section, "gamepad_profile_target", "") as String
+	if steam_is_underlay and not profile_gamepad.is_empty():
+		# Steam Input binds to the controller it saw at startup, so swapping the
+		# emulated controller per-game breaks it. Keep the session-wide target.
+		logger.debug("Ignoring per-game gamepad target '" + profile_gamepad + "'. Steam is the underlay process")
+		profile_gamepad = ""
 	if profile_path.is_empty():
 		logger.debug("Using global gamepad profile")
 	else:

--- a/core/systems/input/input_manager.gd
+++ b/core/systems/input/input_manager.gd
@@ -82,6 +82,12 @@ func get_default_global_profile_path() -> String:
 	return "user://data/gamepad/profiles/global_default.json"
 
 
+## Returns the InputPlumber target device to emulate when the user has not
+## configured one.
+func get_default_target_gamepad() -> String:
+	return ""
+
+
 ## Returns true if the given event is an InputPlumber event
 static func is_inputplumber_event(event: InputEvent) -> bool:
 	return event.has_meta("dbus_path")

--- a/core/systems/input/input_manager_test.gd
+++ b/core/systems/input/input_manager_test.gd
@@ -1,0 +1,17 @@
+extends GutTest
+
+
+# Test that the default input manager makes no assumptions about the target
+# gamepad, leaving whatever target InputPlumber already configured in place.
+func test_get_default_target_gamepad() -> void:
+	var input_manager := InputManager.new()
+	assert_eq(input_manager.get_default_target_gamepad(), "", "should not default to any target gamepad")
+	input_manager.free()
+
+
+# Test that overlay mode emulates a Steam Deck controller by default, so games
+# running under the underlay see the same controller they would on a Deck.
+func test_get_default_target_gamepad_overlay_mode() -> void:
+	var input_manager := OverlayInputManager.new()
+	assert_eq(input_manager.get_default_target_gamepad(), "deck-uhid", "should default to the Steam Deck target gamepad")
+	input_manager.free()

--- a/core/systems/input/input_manager_test.gd
+++ b/core/systems/input/input_manager_test.gd
@@ -9,9 +9,19 @@ func test_get_default_target_gamepad() -> void:
 	input_manager.free()
 
 
-# Test that overlay mode emulates a Steam Deck controller by default, so games
-# running under the underlay see the same controller they would on a Deck.
+# Test that overlay mode only assumes a target gamepad when Steam is the
+# underlay process, so games running under Steam see the same controller they
+# would on a Deck while other underlays keep whatever is already configured.
 func test_get_default_target_gamepad_overlay_mode() -> void:
+	var launch_manager := load("res://core/global/launch_manager.tres") as LaunchManager
+	var was_underlay := launch_manager.steam_is_underlay
 	var input_manager := OverlayInputManager.new()
-	assert_eq(input_manager.get_default_target_gamepad(), "deck-uhid", "should default to the Steam Deck target gamepad")
+
+	launch_manager.steam_is_underlay = false
+	assert_eq(input_manager.get_default_target_gamepad(), "", "should not default to any target gamepad without Steam")
+
+	launch_manager.steam_is_underlay = true
+	assert_eq(input_manager.get_default_target_gamepad(), "deck-uhid", "should default to the Steam Deck target gamepad under Steam")
+
+	launch_manager.steam_is_underlay = was_underlay
 	input_manager.free()

--- a/core/systems/input/overlay_mode_input_manager.gd
+++ b/core/systems/input/overlay_mode_input_manager.gd
@@ -30,6 +30,12 @@ func _get_default_profile_path() -> String:
 	return "res://assets/gamepad/profiles/default_overlay.json"
 
 
+## In overlay mode we run alongside an underlay like Steam
+## Emulate a steam deck controller by default
+func get_default_target_gamepad() -> String:
+	return "deck-uhid"
+
+
 func get_default_global_profile_path() -> String:
 	return "user://data/gamepad/profiles/global_default_overlay.json"
 

--- a/core/systems/input/overlay_mode_input_manager.gd
+++ b/core/systems/input/overlay_mode_input_manager.gd
@@ -33,6 +33,8 @@ func _get_default_profile_path() -> String:
 ## In overlay mode we run alongside an underlay like Steam
 ## Emulate a steam deck controller by default
 func get_default_target_gamepad() -> String:
+	if not launch_manager.steam_is_underlay:
+		return ""
 	return "deck-uhid"
 
 

--- a/core/ui/card_ui/gamepad/gamepad_settings.gd
+++ b/core/ui/card_ui/gamepad/gamepad_settings.gd
@@ -73,6 +73,7 @@ func _ready() -> void:
 
 	# Load the default profile for every attached gamepad
 	var profile_path = settings_manager.get_value("input", "gamepad_profile", "")
+	var saved_gamepad := settings_manager.get_value("input", "gamepad_profile_target", "") as String
 	for composite_device in input_plumber.get_composite_devices():
 		# Set the current profile_gamepad type to the currently configured CompositeDevice target gamepad
 		var targets = composite_device.get_target_devices()
@@ -80,7 +81,10 @@ func _ready() -> void:
 			var target_dbus_path: String = target.get("dbus_path")
 			if not target_dbus_path.contains("target/gamepad"):
 				continue
-			self.profile_gamepad = target.get("device_type")
+			if saved_gamepad.is_empty():
+				self.profile_gamepad = target.get("device_type")
+			else:
+				self.profile_gamepad = saved_gamepad
 			_set_gamepad_profile(composite_device, profile_path)
 			break
 
@@ -630,6 +634,12 @@ func _set_gamepad_profile(device: CompositeDevice, profile_path: String = "") ->
 			profile_path = settings_manager.get_value("input", "gamepad_profile", profile_path) as String
 		else:
 			profile_path = settings_manager.get_library_value(library_item, "gamepad_profile", "")
+
+	if self.profile_gamepad.is_empty():
+		if not library_item:
+			self.profile_gamepad = settings_manager.get_value("input", "gamepad_profile_target", "") as String
+		else:
+			self.profile_gamepad = settings_manager.get_library_value(library_item, "gamepad_profile_target", "") as String
 
 	logger.debug("Setting " + device.name + " to profile: " + profile_path)
 	InputPlumber.load_target_modified_profile(device, profile_path, self.profile_gamepad)

--- a/core/ui/card_ui/gamepad/gamepad_settings.gd
+++ b/core/ui/card_ui/gamepad/gamepad_settings.gd
@@ -74,6 +74,7 @@ func _ready() -> void:
 	# Load the default profile for every attached gamepad
 	var profile_path = settings_manager.get_value("input", "gamepad_profile", "")
 	var saved_gamepad := settings_manager.get_value("input", "gamepad_profile_target", "") as String
+	var default_gamepad := input_manager.get_default_target_gamepad()
 	for composite_device in input_plumber.get_composite_devices():
 		# Set the current profile_gamepad type to the currently configured CompositeDevice target gamepad
 		var targets = composite_device.get_target_devices()
@@ -81,10 +82,12 @@ func _ready() -> void:
 			var target_dbus_path: String = target.get("dbus_path")
 			if not target_dbus_path.contains("target/gamepad"):
 				continue
-			if saved_gamepad.is_empty():
-				self.profile_gamepad = target.get("device_type")
-			else:
+			if not saved_gamepad.is_empty():
 				self.profile_gamepad = saved_gamepad
+			elif not default_gamepad.is_empty():
+				self.profile_gamepad = default_gamepad
+			else:
+				self.profile_gamepad = target.get("device_type")
 			_set_gamepad_profile(composite_device, profile_path)
 			break
 
@@ -640,6 +643,10 @@ func _set_gamepad_profile(device: CompositeDevice, profile_path: String = "") ->
 			self.profile_gamepad = settings_manager.get_value("input", "gamepad_profile_target", "") as String
 		else:
 			self.profile_gamepad = settings_manager.get_library_value(library_item, "gamepad_profile_target", "") as String
+	if self.profile_gamepad.is_empty() and is_instance_valid(input_manager):
+		# Fall back to the default for the current mode, so devices added after
+		# startup get the same target gamepad as the ones present at startup.
+		self.profile_gamepad = input_manager.get_default_target_gamepad()
 
 	logger.debug("Setting " + device.name + " to profile: " + profile_path)
 	InputPlumber.load_target_modified_profile(device, profile_path, self.profile_gamepad)

--- a/core/ui/card_ui/gamepad/gamepad_settings.gd
+++ b/core/ui/card_ui/gamepad/gamepad_settings.gd
@@ -179,8 +179,13 @@ func _on_state_entered(_from: State) -> void:
 	else:
 		self.profile_label.text = self.library_item.name
 		profile_path = settings_manager.get_library_value(self.library_item, "gamepad_profile", "") as String
-		# Check if we have a profile target, otherwise use the currently set one
-		self.profile_gamepad = settings_manager.get_library_value(self.library_item, "gamepad_profile_target", self.profile_gamepad) as String
+		if launch_manager.steam_is_underlay:
+			self.profile_gamepad = settings_manager.get_value("input", "gamepad_profile_target", self.profile_gamepad)
+		else:
+			self.profile_gamepad = settings_manager.get_library_value(self.library_item, "gamepad_profile_target", self.profile_gamepad) as String
+
+	# Don't offer a per-game controller picker that we're going to ignore
+	gamepad_type_dropdown.disabled = self.library_item != null and launch_manager.steam_is_underlay
 
 	self.profile = _load_profile(profile_path)
 	logger.debug("Set profile target gamepad to " + self.profile_gamepad)
@@ -639,7 +644,7 @@ func _set_gamepad_profile(device: CompositeDevice, profile_path: String = "") ->
 			profile_path = settings_manager.get_library_value(library_item, "gamepad_profile", "")
 
 	if self.profile_gamepad.is_empty():
-		if not library_item:
+		if not library_item or launch_manager.steam_is_underlay:
 			self.profile_gamepad = settings_manager.get_value("input", "gamepad_profile_target", "") as String
 		else:
 			self.profile_gamepad = settings_manager.get_library_value(library_item, "gamepad_profile_target", "") as String
@@ -706,7 +711,8 @@ func _save_profile() -> void:
 	# Update the game settings to use this gamepad profile
 	var section := "game.{0}".format([library_item.name.to_lower()])
 	settings_manager.set_value(section, "gamepad_profile", path)
-	settings_manager.set_value(section, "gamepad_profile_target", self.profile_gamepad)
+	if not launch_manager.steam_is_underlay:
+		settings_manager.set_value(section, "gamepad_profile_target", self.profile_gamepad)
 	logger.debug("Saved gamepad profile to: " + path)
 	notify.text = "Gamepad profile saved"
 	notification_manager.show(notify)

--- a/core/ui/card_ui_overlay_mode/card_ui_overlay_mode.gd
+++ b/core/ui/card_ui_overlay_mode/card_ui_overlay_mode.gd
@@ -77,6 +77,19 @@ func _init():
 	# Ensure LaunchManager doesn't override our custom overlay management l
 	launch_manager.should_manage_overlay = false
 
+	# Workaround old versions that don't pass launch args via update pack
+	# TODO: Parse the parent PID's CLI args and use those instead.
+	if "--skip-update-pack" in cmdargs and launch_args.size() == 0:
+		logger.warn("Launched via update pack without arguments! Falling back to default.")
+		launch_args = PackedStringArray(["steam", "-gamepadui", "-steamos3", "-steampal", "-steamdeck"])
+
+	# Steam Input manages the emulated controller itself. This has to stay in
+	# _init(), which runs before our children are instantiated -- the input
+	# manager and gamepad settings menu both read this during their _ready().
+	if "steam" in launch_args:
+		logger.info("Steam is the underlay process. The emulated controller is managed by the session")
+		launch_manager.steam_is_underlay = true
+
 	# Set up plugin manager for quick-bar tags
 	var plugin_loader := load("res://core/global/plugin_loader.tres") as PluginLoader
 	var filters : Array[Callable] = [plugin_loader.filter_by_tag.bind("quick-bar")]
@@ -88,12 +101,6 @@ func _init():
 
 ## Starts the --overlay-mode session.
 func _ready() -> void:
-	# Workaround old versions that don't pass launch args via update pack
-	# TODO: Parse the parent PID's CLI args and use those instead.
-	if "--skip-update-pack" in cmdargs and launch_args.size() == 0:
-		logger.warn("Launched via update pack without arguments! Falling back to default.")
-		launch_args = PackedStringArray(["steam", "-gamepadui", "-steamos3", "-steampal", "-steamdeck"])
-
 	# Configure the locale
 	logger.debug("Setup Locale")
 	var locale := settings_manager.get_value("general", "locale", "en_US") as String


### PR DESCRIPTION
Without this, the user specified controller in OGUI is reset on every boot to the default, regardless of what's actually saved to the user's config.