### PR TITLE
rootfs: Add udev rule for AYANEO 3 magic module controls

### DIFF
--- a/rootfs/usr/lib/udev/rules.d/70-ayaneo-modules.rules
+++ b/rootfs/usr/lib/udev/rules.d/70-ayaneo-modules.rules
@@ -1,18 +1,8 @@
-# AYANEO 3 detachable controller ("Magic Modules") control attributes.
-#
-# Grants unprivileged access to the sysfs controls exposed by the
-# hid-ayaneo HID driver (module eject/reset) and the ayaneo-ec platform
-# driver (controller power), so the OpenGamepadUI magic-modules plugin
-# can drive the pop-out flow without privileges. These are local
-# physical controls with no data exposure.
-#
-# udev cannot set permissions on arbitrary sysfs attributes directly
-# (MODE/uaccess only apply to device nodes), hence RUN+chmod. The HID
-# device rebinds on every controller power cycle, so the rule must
-# match add|bind.
+# AYANEO 3 magic-module controls for the OpenGamepadUI plugin.
+# sysfs attributes cannot take MODE= (device nodes only), hence RUN.
 
-ACTION=="add|bind", SUBSYSTEM=="hid", DRIVER=="hid-ayaneo", \
-  RUN+="/bin/sh -c 'chmod 0666 /sys%p/eject /sys%p/reset'"
+ACTION=="add|bind", SUBSYSTEM=="hid", DRIVER=="hid-ayaneo", TEST=="eject", \
+  RUN+="/bin/chmod 0666 /sys%p/eject /sys%p/reset"
 
-ACTION=="add", DEVPATH=="*/platform/ayaneo-ec", \
-  RUN+="/bin/sh -c 'chmod 0666 /sys%p/controller_power'"
+ACTION=="add", DEVPATH=="*/platform/ayaneo-ec", TEST=="controller_power", \
+  RUN+="/bin/chmod 0666 /sys%p/controller_power"

--- a/rootfs/usr/lib/udev/rules.d/70-ayaneo-modules.rules
+++ b/rootfs/usr/lib/udev/rules.d/70-ayaneo-modules.rules
@@ -1,0 +1,18 @@
+# AYANEO 3 detachable controller ("Magic Modules") control attributes.
+#
+# Grants unprivileged access to the sysfs controls exposed by the
+# hid-ayaneo HID driver (module eject/reset) and the ayaneo-ec platform
+# driver (controller power), so the OpenGamepadUI magic-modules plugin
+# can drive the pop-out flow without privileges. These are local
+# physical controls with no data exposure.
+#
+# udev cannot set permissions on arbitrary sysfs attributes directly
+# (MODE/uaccess only apply to device nodes), hence RUN+chmod. The HID
+# device rebinds on every controller power cycle, so the rule must
+# match add|bind.
+
+ACTION=="add|bind", SUBSYSTEM=="hid", DRIVER=="hid-ayaneo", \
+  RUN+="/bin/sh -c 'chmod 0666 /sys%p/eject /sys%p/reset'"
+
+ACTION=="add", DEVPATH=="*/platform/ayaneo-ec", \
+  RUN+="/bin/sh -c 'chmod 0666 /sys%p/controller_power'"


### PR DESCRIPTION
Prerequisite for the AYANEO magic-modules quick-bar plugin, as requested in #528: grants unprivileged access to the sysfs controls the plugin drives — `eject`/`reset` on the [hid-ayaneo driver](https://github.com/OpenGamingCollective/linux-unstable/pull/3) and `controller_power` on the mainline ayaneo-ec driver.

Notes:
- udev can't set permissions on sysfs *attributes* via `MODE`/`uaccess` (device nodes only), hence the `RUN`+chmod form. The HID device rebinds on every controller power cycle, so the rule matches `add|bind`.
- Went with `0666` since these are local physical controls with no data exposure and there's no cross-distro group to target; happy to switch to a group-write model if you prefer one.
- Verified on an AYANEO 3 running Bazzite 44: with this rule the plugin performs the full eject → power-cut → reinsert → repower cycle unprivileged.

The plugin itself: https://github.com/matmartinez/ayaneo-3-bazzite-compat/tree/main/ogui-plugin — registry PR to OpenGamepadUI-plugins to follow once this lands. (While building it I also hit #535, which affects all quick-bar plugins in overlay mode.)